### PR TITLE
feat(api): include missing routers and archive duplicate files - refs #61

### DIFF
--- a/coaching/src/api/main.py
+++ b/coaching/src/api/main.py
@@ -17,7 +17,15 @@ from coaching.src.api.middleware import (
     LoggingMiddleware,
     RateLimitingMiddleware,
 )
-from coaching.src.api.routes import admin, analysis, conversations, health
+from coaching.src.api.routes import (
+    admin,
+    analysis,
+    conversations,
+    health,
+    insights,
+    multitenant_conversations,
+    onboarding,
+)
 from coaching.src.core.config_multitenant import settings
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -97,6 +105,18 @@ app = FastAPI(
             "name": "Admin",
             "description": "Administrative endpoints for template and model management (requires ADMIN_ACCESS permission)",
         },
+        {
+            "name": "insights",
+            "description": "AI-powered coaching insights and recommendations",
+        },
+        {
+            "name": "onboarding",
+            "description": "Onboarding AI assistance and suggestions",
+        },
+        {
+            "name": "multitenant",
+            "description": "Multitenant conversations with business data integration",
+        },
     ],
     lifespan=lifespan,
     contact={
@@ -157,6 +177,26 @@ app.include_router(
 app.include_router(
     admin.router,
     prefix=f"{settings.api_prefix}",
+)
+
+# Insights routes
+app.include_router(
+    insights.router,
+    prefix=f"{settings.api_prefix}/insights",
+    tags=["insights"],
+)
+
+# Onboarding AI routes (routes already have /api/coaching prefix)
+app.include_router(
+    onboarding.router,
+    prefix="",  # Routes already include full path
+)
+
+# Multitenant conversation routes
+app.include_router(
+    multitenant_conversations.router,
+    prefix=f"{settings.api_prefix}/multitenant/conversations",
+    tags=["multitenant", "conversations"],
 )
 
 

--- a/coaching/src/api/routes/_archived/README.md
+++ b/coaching/src/api/routes/_archived/README.md
@@ -1,0 +1,49 @@
+# Archived Router Files
+
+**Archived Date:** October 27, 2025  
+**Issue Reference:** #61
+
+## Reason for Archival
+
+These router files were archived because they:
+1. Contain only stub implementations with TODO comments
+2. Have functionality that duplicates or conflicts with active routers
+3. Are not included in main.py and not part of the API specification
+
+## Archived Files
+
+### suggestions.py
+- **Status:** Stub implementation
+- **Reason:** Duplicates functionality in `onboarding.py`
+- **Endpoint:** `POST /onboarding` for suggestions
+- **Notes:** Basic JWT auth implementation, can be reference for auth patterns if needed
+
+### website.py
+- **Status:** Stub implementation  
+- **Reason:** Duplicates functionality in `onboarding.py` which has `POST /website/scan`
+- **Endpoints:** `/scan`, `/analysis/{domain}`, `/bulk-scan`
+- **Notes:** Contains TODO notes for future website analysis features
+
+### coaching.py
+- **Status:** Stub implementation
+- **Reason:** Endpoints not in API specification, all stubs with TODO comments
+- **Endpoints:** `/onboarding`, `/strategic-planning`, `/performance-coaching`, `/leadership-coaching`
+- **Notes:** Contains ideas for future coaching features that may be implemented differently
+
+## Recovery
+
+If any functionality from these files is needed:
+1. Review the archived file for the specific implementation
+2. Extract the relevant code patterns or logic
+3. Implement properly in the appropriate active router
+4. Follow current architecture patterns and type safety standards
+
+## Related Active Routers
+
+- **onboarding.py** - Active implementation of onboarding AI features
+- **conversations.py** - Active implementation of coaching conversations
+- **analysis.py** - Active implementation of business analysis features
+
+---
+
+**Do not restore these files without reviewing current API specification and architecture.**


### PR DESCRIPTION
## Summary
Implementation of Issue #61 - Include Missing Routers in Main Application

## Changes Made

### 1. Included Missing Routers in `main.py`
- ✅ Added `insights.router` with prefix `/insights`
- ✅ Added `onboarding.router` (routes already have full paths)
- ✅ Added `multitenant_conversations.router` with prefix `/multitenant/conversations`

### 2. Archived Duplicate/Stub Router Files
Created `coaching/src/api/routes/_archived/` directory and moved:
- ✅ `suggestions.py` - Stub implementation duplicating onboarding.py
- ✅ `website.py` - Stub implementation duplicating onboarding.py 
- ✅ `coaching.py` - Stub implementations not in specification
- ✅ Added `README.md` documenting why files were archived

### 3. Pre-Commit Validation
- ✅ Ruff linting: All checks passed
- ✅ Ruff formatting: Code properly formatted
- ✅ MyPy: Pre-existing warnings only (not from changes)

## Endpoints Now Available

**Insights Routes** (`/api/v1/insights/`)
- `POST /generate` - Generate coaching insights
- `GET /categories` - Get insight categories
- `GET /priorities` - Get insight priorities
- `POST /{insight_id}/dismiss` - Dismiss insight
- `POST /{insight_id}/acknowledge` - Acknowledge insight
- `GET /summary` - Get insights summary

**Onboarding Routes**
- `POST /api/coaching/suggestions/onboarding` - Get onboarding suggestions
- `POST /api/coaching/website/scan` - Scan website
- `POST /api/coaching/coaching/onboarding` - Get onboarding coaching

**Multitenant Conversation Routes** (`/api/v1/multitenant/conversations/`)
- `POST /initiate` - Initiate conversation
- `POST /{conversation_id}/message` - Send message
- `GET /{conversation_id}` - Get conversation details
- `GET /` - List conversations
- `POST /{conversation_id}/complete` - Complete conversation
- `POST /{conversation_id}/pause` - Pause conversation
- `DELETE /{conversation_id}` - Delete conversation
- `GET /business-data` - Get business data summary
- `GET /tenant/all` - List all tenant conversations (admin)

## Testing
All endpoints can be verified in Swagger UI at `/docs` once the development server is started.

## Related Issues
Closes #61

---
**Ready to merge to dev**