### PR TITLE
fix(llm): convert DynamoDB Decimal to int for max_tokens - refs #139

### DIFF
--- a/coaching/src/domain/entities/llm_topic.py
+++ b/coaching/src/domain/entities/llm_topic.py
@@ -310,7 +310,7 @@ class LLMTopic:
             config = item["config"]
             model_code = config.get("model_code", "claude-3-5-sonnet-20241022")
             temperature = float(config.get("temperature", 0.7))
-            max_tokens = config.get("max_tokens", 2000)
+            max_tokens = int(config.get("max_tokens", 2000))
             top_p = float(config.get("top_p", 1.0))
             frequency_penalty = float(config.get("frequency_penalty", 0.0))
             presence_penalty = float(config.get("presence_penalty", 0.0))
@@ -329,9 +329,9 @@ class LLMTopic:
             }
         else:
             # New format: explicit fields
-            # Convert Decimal to float for DynamoDB compatibility
+            # Convert Decimal to int/float for DynamoDB compatibility
             temperature = float(item.get("temperature", 0.7))
-            max_tokens = item.get("max_tokens", 2000)
+            max_tokens = int(item.get("max_tokens", 2000))
             top_p = float(item.get("top_p", 1.0))
             frequency_penalty = float(item.get("frequency_penalty", 0.0))
             presence_penalty = float(item.get("presence_penalty", 0.0))


### PR DESCRIPTION
## Summary

Fixes the 500 error when calling the unified AI endpoint (`POST /ai/execute`) with the error:
```
Object of type Decimal is not JSON serializable
```

## Root Cause

In `LLMTopic.from_dynamodb_item()`, the `temperature`, `top_p`, etc. were converted from DynamoDB `Decimal` to Python `float`, but **`max_tokens` was not converted to `int`**.

When DynamoDB returns `Decimal('2000')` for `max_tokens`, it passed through unchanged to the OpenAI provider which failed to serialize it to JSON.

## Solution

Convert `max_tokens` to `int` in both code paths of `from_dynamodb_item()`:

```python
# Before (BUG)
max_tokens = item.get("max_tokens", 2000)

# After (FIX)
max_tokens = int(item.get("max_tokens", 2000))
```

## Changes

- `coaching/src/domain/entities/llm_topic.py`: Convert `max_tokens` to `int` in both old and new config format paths
- `coaching/tests/unit/domain/entities/test_llm_topic.py`: Add regression tests for Decimal conversion

## Testing

- ✅ All unit tests passing (1102 passed)
- ✅ New regression tests verify Decimal→int/float conversion
- ✅ Tests verify JSON serialization works after conversion
- ✅ Pre-commit checks passed

Closes #139