### PR TITLE
ci: Update workflow triggers to run on approval/push only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: CI/CD Pipeline
 
 on:
-  pull_request:
+  # Only trigger on push to dev/main (after PR merge)
+  push:
     branches:
       - dev
       - main
+    paths:
+      - 'coaching/**/*.py'
+      - 'shared/**/*.py'
+      - 'pyproject.toml'
+      - 'pytest.ini'
+  # Allow manual trigger
+  workflow_dispatch: {}
 
 jobs:
   lint-and-test:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,20 +1,19 @@
 name: PR Checks
 
 on:
-  pull_request:
+  # Trigger on PR approval only
+  pull_request_review:
+    types: [submitted]
     branches: [dev, main, staging]
-    paths:
-      - 'coaching/**/*.py'
-      - 'shared/**/*.py'
-      - 'pyproject.toml'
-      - 'pytest.ini'
-      - '.github/workflows/pr-checks.yml'
+  # Allow manual trigger
   workflow_dispatch: {}
 
 jobs:
   code-quality:
     name: Code Quality Checks
     runs-on: ubuntu-latest
+    # Only run if the review was an approval OR triggered manually
+    if: github.event.review.state == 'approved' || github.event_name == 'workflow_dispatch'
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Updates GitHub Actions workflow triggers to prevent unnecessary pipeline runs.

## Changes

### `pr-checks.yml`
- Changed trigger from `pull_request` to `pull_request_review` with `submitted` type
- Added condition to only run when review state is `approved`
- Retained `workflow_dispatch` for manual triggers

### `ci.yml`
- Changed trigger from `pull_request` to `push` on dev/main branches
- Added path filters to only run when Python code changes
- Added `workflow_dispatch` for manual triggers

## Behavior After Change

| Event | Workflow Triggered |
|-------|-------------------|
| PR opened | ❌ No pipeline |
| Issue created | ❌ No pipeline (only project board) |
| PR approved | ✅ `pr-checks.yml` runs |
| Push to dev | ✅ `ci.yml` + `deploy-dev.yml` run |
| Manual trigger | ✅ Any workflow |

## Testing
- Manual trigger via `workflow_dispatch` still available
- Merging this PR will test the push trigger