### PR TITLE
fix: retain LLM formatting with newlines in response text

### DIFF
--- a/coaching/src/api/models/onboarding.py
+++ b/coaching/src/api/models/onboarding.py
@@ -123,7 +123,10 @@ class SuggestionVariation(BaseModel):
     )
     reasoning: str = Field(
         ...,
-        description="Explanation of why this variation is recommended",
+        description=(
+            "Explanation of why this variation is recommended. "
+            "Use newlines (\\n) to separate paragraphs for readability."
+        ),
     )
 
 
@@ -136,7 +139,11 @@ class OnboardingReviewResponse(BaseModel):
     quality_review: str = Field(
         ...,
         alias="qualityReview",
-        description="AI review of the current content quality with feedback",
+        description=(
+            "AI review of the current content quality with feedback. "
+            "Use newlines (\\n) to separate sections like Overall Assessment, "
+            "Strengths, Weaknesses, and Suggestions for readability."
+        ),
     )
     suggestions: list[SuggestionVariation] = Field(
         ...,

--- a/coaching/src/application/ai_engine/unified_ai_engine.py
+++ b/coaching/src/application/ai_engine/unified_ai_engine.py
@@ -44,7 +44,9 @@ You MUST respond with valid JSON that matches this exact schema:
 - Use the exact field names shown above (including camelCase where specified by "alias")
 - Do not include any text before or after the JSON
 - Ensure all required fields are present
-- Follow any constraints (min/max length, enum values, etc.)"""
+- Follow any constraints (min/max length, enum values, etc.)
+- For text fields with multiple sections or paragraphs, use newlines (\\n) to separate them for readability
+- Preserve logical paragraph breaks in your responses using \\n characters"""
 
 
 class UnifiedAIEngineError(Exception):


### PR DESCRIPTION
## Summary

This PR fixes issue #151 by instructing the LLM to include newline characters (`\n`) in text responses for proper paragraph formatting.

## Problem

LLM review responses (for `niche_review`, `ica_review`, `value_proposition_review` topics) were returned as one continuous block of text without any paragraph breaks. The frontend can display newlines correctly, but the API was not providing them.

## Solution

Two-pronged fix:

1. **Updated `OnboardingReviewResponse` model** ([onboarding.py](coaching/src/api/models/onboarding.py))
   - Added formatting instructions in `quality_review` field description
   - Added formatting instructions in `SuggestionVariation.reasoning` field description
   - These descriptions are included in the JSON schema sent to the LLM

2. **Updated `RESPONSE_FORMAT_INSTRUCTIONS`** ([unified_ai_engine.py](coaching/src/application/ai_engine/unified_ai_engine.py))
   - Added general instruction for all topics to use `\n` for paragraph breaks in text fields
   - This ensures consistent formatting across all topic responses

## Testing

- ✅ All existing unit tests pass (52 onboarding-related tests)
- ✅ All unified AI engine tests pass (12 tests)
- ✅ Ruff linting passes
- ✅ Pre-commit checks pass

## Closes

Closes #151