### PR TITLE
ci: deploy production infra and service with Pulumi

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -110,11 +110,52 @@ jobs:
         env:
           PYTHONPATH: coaching:shared:.
 
-  deploy-coaching:
-    name: Deploy to Production
+  deploy-infrastructure:
+    name: Deploy Infrastructure
     runs-on: ubuntu-latest
     needs: [validate-promotion, pre-deployment-checks]
     if: ${{ needs.validate-promotion.outputs.should_deploy == 'true' && (needs.pre-deployment-checks.result == 'success' || (github.event_name == 'workflow_dispatch' && github.event.inputs.skip_tests == 'true')) }}
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Pulumi Python dependencies
+        working-directory: infrastructure/pulumi
+        run: pip install -r requirements.txt
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Deploy Infrastructure
+        uses: pulumi/actions@v5
+        with:
+          command: up
+          stack-name: prod
+          work-dir: infrastructure/pulumi
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+
+  deploy-coaching:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: [validate-promotion, deploy-infrastructure]
+    if: ${{ needs.validate-promotion.outputs.should_deploy == 'true' && needs.deploy-infrastructure.result == 'success' }}
     permissions:
       id-token: write
       contents: write

--- a/docs/operations/PRODUCTION_PROMOTION_CHECKLIST.md
+++ b/docs/operations/PRODUCTION_PROMOTION_CHECKLIST.md
@@ -76,10 +76,10 @@ aws dynamodb list-tables --output table
 
 ## 6) Pulumi Stack Readiness
 
-Production deploy workflow currently targets stack name `prod`.
+Production deploy workflow targets stack name `prod` for both projects.
 
 - [ ] `coaching/pulumi` has stack `prod`
-- [ ] If infrastructure is managed separately, production infra stack is deployed and stable
+- [ ] `infrastructure/pulumi` has stack `prod`
 
 Quick checks:
 


### PR DESCRIPTION
## Summary
- update production workflow to deploy infrastructure before service using Pulumi
- keep staging-to-master PR merge as the only automatic production trigger
- update production checklist to require prod stacks for both Pulumi projects

## Why
Production promotions should apply both infra and service changes in a single reliable flow.

Made with [Cursor](https://cursor.com)