### PR TITLE
ci: remove pip cache from production pre-checks

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Summary
- remove cache: pip from production pre-deployment Python setup
- keep uv-based dependency install unchanged

## Why
setup-python cache cleanup fails when pip cache path does not exist, causing false-negative production gate failures.

Made with [Cursor](https://cursor.com)