### PR TITLE
release: promote staging to master after cache fix

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
## Summary
- promote latest staging to master after fixing setup-python cache failure in production checks
- keeps Pulumi infra + service production deployment flow
- keeps unit-test gate for reliable production promotion

## Validation
- latest staging deployment and smoke tests passed

Made with [Cursor](https://cursor.com)