### PR TITLE
infra: support existing ECR repo and add prod stack config files

### DIFF
--- a/coaching/pulumi/Pulumi.prod.yaml
+++ b/coaching/pulumi/Pulumi.prod.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-east-1

--- a/infrastructure/pulumi/Pulumi.prod.yaml
+++ b/infrastructure/pulumi/Pulumi.prod.yaml
@@ -1,0 +1,2 @@
+config:
+  aws:region: us-east-1


### PR DESCRIPTION
## Summary
- reuse existing purposepath-coaching ECR repository in coaching Pulumi to avoid duplicate repository creation
- add Pulumi.prod.yaml for both Pulumi projects with ws:region config

## Why
Production deployment failed because infrastructure stack was missing and coaching stack attempted to recreate an existing global ECR repository. This change makes production stack deployment idempotent and reliable.

Made with [Cursor](https://cursor.com)