### PR TITLE
fix(#236): align admin topics auth, type naming, and model codes

### DIFF
--- a/coaching/src/api/routes/admin/prompts.py
+++ b/coaching/src/api/routes/admin/prompts.py
@@ -18,6 +18,7 @@ from typing import Annotated
 import structlog
 from coaching.src.api.dependencies import get_s3_prompt_storage, get_topic_repository
 from coaching.src.api.middleware.admin_auth import require_admin_access
+from coaching.src.core.llm_models import DEFAULT_MODEL_CODE
 from coaching.src.core.topic_registry import get_parameters_for_topic
 from coaching.src.domain.entities.llm_topic import LLMTopic, ParameterDefinition, PromptInfo
 from coaching.src.domain.exceptions.topic_exceptions import (
@@ -169,7 +170,7 @@ async def list_topics(
     """
     List all topics, optionally filtered by type.
 
-    - **topic_type**: Filter by conversation_coaching, single_shot, or kpi_system
+    - **topic_type**: Filter by conversation_coaching, single_shot, or measure_system
     - **include_inactive**: Include topics marked as inactive
 
     Returns:
@@ -209,9 +210,9 @@ async def create_topic(
     context: RequestContext = Depends(require_admin_access),
 ) -> ApiResponse[TopicResponse]:
     """
-    Create a new KPI-system topic.
+    Create a new measure-system topic.
 
-    Only kpi_system topics can be created via API.
+    Only measure_system topics can be created via API.
     Coaching topics are seeded at deployment.
 
     Args:
@@ -232,7 +233,7 @@ async def create_topic(
         config_dict = request.config.model_dump()
 
         # Map default_model to model_code
-        model_code = config_dict.pop("default_model", "claude-3-5-sonnet-20241022")
+        model_code = config_dict.pop("default_model", DEFAULT_MODEL_CODE)
         # Also check for model_code just in case
         if "model_code" in config_dict:
             model_code = config_dict.pop("model_code")

--- a/coaching/src/core/topic_seed_data.py
+++ b/coaching/src/core/topic_seed_data.py
@@ -32,7 +32,7 @@ class TopicSeedData:
     Attributes:
         topic_id: Unique identifier (snake_case)
         topic_name: Human-readable display name
-        topic_type: Type (conversation_coaching, single_shot, kpi_system)
+        topic_type: Type (conversation_coaching, single_shot, measure_system)
         category: Grouping category
         description: Detailed description of topic purpose
         tier_level: Subscription tier required to access this topic
@@ -1862,7 +1862,7 @@ def get_seed_data_by_type(topic_type: str) -> list[TopicSeedData]:
     """Get seed data for topics of a specific type.
 
     Args:
-        topic_type: Topic type (conversation_coaching, single_shot, kpi_system)
+        topic_type: Topic type (conversation_coaching, single_shot, measure_system)
 
     Returns:
         List of TopicSeedData for the type

--- a/coaching/src/domain/exceptions/topic_exceptions.py
+++ b/coaching/src/domain/exceptions/topic_exceptions.py
@@ -55,7 +55,7 @@ class InvalidTopicTypeError(DomainError):
     """
     Raised when a topic has an invalid topic_type value.
 
-    Business Rule: topic_type must be one of: conversation_coaching, single_shot, kpi_system
+    Business Rule: topic_type must be one of: conversation_coaching, single_shot, measure_system
     """
 
     def __init__(self, *, topic_id: str, invalid_type: str) -> None:
@@ -68,7 +68,7 @@ class InvalidTopicTypeError(DomainError):
         """
         super().__init__(
             message=f"Invalid topic type '{invalid_type}' for topic '{topic_id}'. "
-            f"Must be one of: conversation_coaching, single_shot, kpi_system",
+            f"Must be one of: conversation_coaching, single_shot, measure_system",
             code="INVALID_TOPIC_TYPE",
             context={"topic_id": topic_id, "invalid_type": invalid_type},
         )

--- a/coaching/src/models/admin_topics.py
+++ b/coaching/src/models/admin_topics.py
@@ -82,7 +82,7 @@ class CreateTopicRequest(BaseModel):
     @classmethod
     def validate_topic_type(cls, v: str) -> str:
         """Validate topic_type is one of allowed values."""
-        allowed = {"conversation_coaching", "single_shot", "kpi_system"}
+        allowed = {"conversation_coaching", "single_shot", "measure_system"}
         if v not in allowed:
             raise ValueError(f"topic_type must be one of: {', '.join(allowed)}")
         return v

--- a/coaching/src/models/prompt_requests.py
+++ b/coaching/src/models/prompt_requests.py
@@ -52,8 +52,8 @@ class CreateTopicRequest(BaseModel):
     )
     topic_type: str = Field(
         ...,
-        pattern=r"^kpi_system$",
-        description="Topic type (only kpi_system allowed via API)",
+        pattern=r"^measure_system$",
+        description="Topic type (only measure_system allowed via API)",
     )
     category: str = Field(
         ...,

--- a/coaching/tests/integration/test_llm_prompts_infrastructure.py
+++ b/coaching/tests/integration/test_llm_prompts_infrastructure.py
@@ -83,7 +83,7 @@ class TestLLMPromptsTableStructure:
 
     def test_topic_type_values(self, sample_topic_item: dict[str, Any]) -> None:
         """Test that topic_type is one of allowed values."""
-        allowed_types = ["conversation_coaching", "single_shot", "kpi_system"]
+        allowed_types = ["conversation_coaching", "single_shot", "measure_system"]
         assert sample_topic_item["topic_type"] in allowed_types
 
     def test_prompts_array_structure(self, sample_topic_item: dict[str, Any]) -> None:
@@ -269,16 +269,16 @@ class TestS3PromptStorage:
         assert "ETag" in response
 
 
-class TestKPISystemTopicStructure:
-    """Test KPI-system specific topic structure."""
+class TestMeasureSystemTopicStructure:
+    """Test measure-system specific topic structure."""
 
     @pytest.fixture
     def kpi_topic_item(self) -> dict[str, Any]:
-        """Sample KPI-system topic."""
+        """Sample measure-system topic."""
         return {
             "topic_id": "revenue_salesforce",
             "topic_name": "Revenue Growth - Salesforce",
-            "topic_type": "kpi_system",
+            "topic_type": "measure_system",
             "category": "kpi",
             "description": "Analyze revenue KPI from Salesforce",
             "display_order": 100,
@@ -303,7 +303,7 @@ class TestKPISystemTopicStructure:
 
     def test_kpi_topic_has_kpi_type(self, kpi_topic_item: dict[str, Any]) -> None:
         """Test that KPI topic has correct topic_type."""
-        assert kpi_topic_item["topic_type"] == "kpi_system"
+        assert kpi_topic_item["topic_type"] == "measure_system"
         assert kpi_topic_item["category"] == "kpi"
 
     def test_kpi_topic_parameters_from_registry(self, kpi_topic_item: dict[str, Any]) -> None:

--- a/coaching/tests/unit/api/routes/admin/test_prompts.py
+++ b/coaching/tests/unit/api/routes/admin/test_prompts.py
@@ -45,13 +45,13 @@ def sample_topic():
     return LLMTopic(
         topic_id="test_topic",
         topic_name="Test Topic",
-        topic_type="kpi_system",
+        topic_type="measure_system",
         category="kpi",
         description="Test Description",
         display_order=1,
         is_active=True,
-        basic_model_code="claude-3-sonnet",
-        premium_model_code="claude-3-sonnet",
+        basic_model_code="CLAUDE_3_5_SONNET_V2",
+        premium_model_code="CLAUDE_3_5_SONNET_V2",
         temperature=0.7,
         max_tokens=1000,
         created_at=datetime.now(UTC),
@@ -76,11 +76,11 @@ class TestListTopics:
     def test_list_topics_filtered(self, client, mock_topic_repo, sample_topic):
         mock_topic_repo.list_by_type.return_value = [sample_topic]
 
-        response = client.get("/prompts?topic_type=kpi_system")
+        response = client.get("/prompts?topic_type=measure_system")
 
         assert response.status_code == status.HTTP_200_OK
         mock_topic_repo.list_by_type.assert_called_once_with(
-            topic_type="kpi_system", include_inactive=False
+            topic_type="measure_system", include_inactive=False
         )
 
     def test_list_topics_error(self, client, mock_topic_repo):
@@ -102,12 +102,12 @@ class TestCreateTopic:
         payload = {
             "topic_id": "new_topic",
             "topic_name": "New Topic",
-            "topic_type": "kpi_system",
+            "topic_type": "measure_system",
             "category": "kpi",
             "description": "New Description",
             "display_order": 2,
             "config": {
-                "default_model": "claude-3-sonnet",
+                "default_model": "CLAUDE_3_5_SONNET_V2",
                 "supports_streaming": True,
                 "max_turns": 10,
                 "temperature": 0.7,
@@ -133,11 +133,11 @@ class TestCreateTopic:
         payload = {
             "topic_id": "existing_topic",
             "topic_name": "Existing Topic",
-            "topic_type": "kpi_system",
+            "topic_type": "measure_system",
             "category": "kpi",
             "description": "Existing Description",
             "display_order": 2,
-            "config": {"default_model": "claude-3-sonnet", "supports_streaming": True},
+            "config": {"default_model": "CLAUDE_3_5_SONNET_V2", "supports_streaming": True},
         }
 
         response = client.post("/prompts", json=payload)

--- a/coaching/tests/unit/domain/entities/test_llm_topic.py
+++ b/coaching/tests/unit/domain/entities/test_llm_topic.py
@@ -201,11 +201,11 @@ class TestLLMTopic:
         )
         assert topic2.topic_type == "single_shot"
 
-        # kpi_system
+        # measure_system
         topic3 = LLMTopic(
             topic_id="kpi",
             topic_name="KPI",
-            topic_type="kpi_system",
+            topic_type="measure_system",
             category="kpi",
             is_active=True,
             basic_model_code="claude-3-5-sonnet-20241022",
@@ -217,7 +217,7 @@ class TestLLMTopic:
             created_at=datetime.now(tz=UTC),
             updated_at=datetime.now(tz=UTC),
         )
-        assert topic3.topic_type == "kpi_system"
+        assert topic3.topic_type == "measure_system"
 
     def test_invalid_topic_type_raises_error(self) -> None:
         """Test that invalid topic_type raises exception."""
@@ -251,8 +251,8 @@ class TestLLMTopic:
         assert item["is_active"] is True
         assert len(item["prompts"]) == 1
         assert item["tier_level"] == "free"
-        assert item["basic_model_code"] == "claude-3-5-sonnet-20241022"
-        assert item["premium_model_code"] == "claude-3-5-sonnet-20241022"
+        assert item["basic_model_code"] == "CLAUDE_3_5_SONNET_V2"
+        assert item["premium_model_code"] == "CLAUDE_3_5_SONNET_V2"
         # DynamoDB requires Decimal for float values
         assert item["temperature"] == Decimal("0.7")
         assert item["max_tokens"] == 2000
@@ -298,8 +298,8 @@ class TestLLMTopic:
         assert len(topic.prompts) == 1
         assert topic.additional_config["key"] == "value"
         # Old config.model_code should migrate to both new fields
-        assert topic.basic_model_code == "claude-3-5-sonnet-20241022"
-        assert topic.premium_model_code == "claude-3-5-sonnet-20241022"
+        assert topic.basic_model_code == "CLAUDE_3_5_SONNET_V2"
+        assert topic.premium_model_code == "CLAUDE_3_5_SONNET_V2"
         assert topic.created_at == datetime(2025, 1, 15, 10, 0, 0, tzinfo=UTC)
         assert topic.updated_at == datetime(2025, 1, 20, 12, 0, 0, tzinfo=UTC)
         assert topic.description == "Test description"
@@ -324,7 +324,7 @@ class TestLLMTopic:
             "topic_type": "single_shot",
             "category": "analysis",
             "is_active": True,
-            "model_code": "gpt-5-mini",
+            "model_code": "GPT_4O_MINI",
             # DynamoDB returns these as Decimal
             "temperature": Decimal("0.8"),
             "max_tokens": Decimal("2000"),
@@ -472,8 +472,8 @@ class TestLLMTopicFactory:
         assert topic.description == "Discover and clarify personal core values"
         assert topic.is_active is False  # Default inactive
         assert topic.display_order == 0  # First enum value
-        assert topic.basic_model_code == "claude-3-5-sonnet-20241022"
-        assert topic.premium_model_code == "claude-3-5-sonnet-20241022"
+        assert topic.basic_model_code == "CLAUDE_3_5_SONNET_V2"
+        assert topic.premium_model_code == "CLAUDE_3_5_SONNET_V2"
         assert topic.temperature == 0.7
         assert topic.max_tokens == 2000
         assert topic.prompts == []  # No prompts until configured


### PR DESCRIPTION
## Summary
- Enforce admin-role access on all /api/v1/admin/topics* routes by switching to equire_admin_access.
- Standardize topic type handling to measure_system and retain legacy kpi_system backward-compat mapping when loading persisted data.
- Normalize and validate model codes against MODEL_REGISTRY, update defaults to canonical registry codes, and sync admin AI spec with implementation.

## Test plan
- [x] uff check on changed Python files
- [x] python -m pytest coaching/tests/unit/api/test_admin_topics.py coaching/tests/unit/domain/entities/test_llm_topic.py coaching/tests/unit/api/routes/admin/test_prompts.py -x --tb=short -q
- [ ] Full strict validation suite (lack, uff, mypy, full unit tests) in CI

Closes #236