### PR TITLE
fix(api): allow wildcard staging CORS origins

### DIFF
--- a/coaching/src/api/main.py
+++ b/coaching/src/api/main.py
@@ -114,8 +114,8 @@ app.add_middleware(CORSPreflightMiddleware)  # type: ignore[arg-type,call-arg]
 # CORS middleware must be added LAST so it runs FIRST in the middleware chain
 # This ensures CORS headers are added before any authentication or error handling
 _cors_config: dict[str, Any] = {
-    # Allow purposepath apex + subdomains, and local dev.
-    "allow_origin_regex": r"https://([a-zA-Z0-9-]+\.)?purposepath\.app|http://localhost:\d+",
+    # Allow purposepath.app + purpopsepath.app apex/subdomains, and local dev ports.
+    "allow_origin_regex": r"(^https://([a-zA-Z0-9-]+\.)*(purposepath|purpopsepath)\.app$)|(^http://localhost:\d+$)",
     "allow_credentials": True,
     "allow_methods": ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
     "allow_headers": [


### PR DESCRIPTION
## Summary
- Update API CORS llow_origin_regex to allow apex + wildcard subdomains for purposepath.app and purpopsepath.app.
- Ensure staging domains like staging.admin.purposepath.app are accepted.
- Keep localhost port origins supported while still rejecting lookalike external domains.

## Test plan
- [x] Validate regex allows https://staging.purposepath.app.
- [x] Validate regex allows https://staging.admin.purposepath.app.
- [x] Validate regex allows https://staging.purpopsepath.app.
- [x] Validate regex rejects https://evilpurposepath.app.evil.com.
- [ ] Deploy to staging and verify browser preflight/actual API calls from staging frontend.