### PR TITLE
fix(cors): prevent cross-layer regressions across environments

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -168,9 +168,36 @@ jobs:
             exit 1
           fi
 
+      - name: CORS Preflight Check
+        run: |
+          echo "Testing CORS preflight behavior..."
+          ORIGIN="https://dev.purposepath.app"
+          TARGET="${{ steps.api-url.outputs.url }}/api/v1/health"
+
+          CORS_HEADERS=$(curl -s -D - -o /dev/null -X OPTIONS "$TARGET" \
+            -H "Origin: $ORIGIN" \
+            -H "Access-Control-Request-Method: GET" \
+            -H "Access-Control-Request-Headers: Authorization,Content-Type")
+
+          ALLOW_ORIGIN=$(echo "$CORS_HEADERS" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}' | tail -n 1)
+          ALLOW_CREDENTIALS=$(echo "$CORS_HEADERS" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-credentials"{print $2}' | tail -n 1)
+
+          if [ "$ALLOW_ORIGIN" != "$ORIGIN" ]; then
+            echo "❌ Invalid Access-Control-Allow-Origin: '$ALLOW_ORIGIN' (expected '$ORIGIN')"
+            exit 1
+          fi
+
+          if [ "$ALLOW_CREDENTIALS" != "true" ]; then
+            echo "❌ Invalid Access-Control-Allow-Credentials: '$ALLOW_CREDENTIALS' (expected 'true')"
+            exit 1
+          fi
+
+          echo "✅ CORS preflight returned expected headers"
+
       - name: Smoke Test Summary
         run: |
           echo "## Smoke Tests - Dev" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ Health check passed" >> $GITHUB_STEP_SUMMARY
           echo "✅ API is responsive" >> $GITHUB_STEP_SUMMARY
+          echo "✅ CORS preflight check passed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -274,12 +274,39 @@ jobs:
             exit 1
           fi
 
+      - name: CORS Preflight Check
+        run: |
+          echo "Testing CORS preflight behavior..."
+          ORIGIN="https://purposepath.app"
+          TARGET="${{ steps.api-url.outputs.url }}/api/v1/health"
+
+          CORS_HEADERS=$(curl -s -D - -o /dev/null -X OPTIONS "$TARGET" \
+            -H "Origin: $ORIGIN" \
+            -H "Access-Control-Request-Method: GET" \
+            -H "Access-Control-Request-Headers: Authorization,Content-Type")
+
+          ALLOW_ORIGIN=$(echo "$CORS_HEADERS" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}' | tail -n 1)
+          ALLOW_CREDENTIALS=$(echo "$CORS_HEADERS" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-credentials"{print $2}' | tail -n 1)
+
+          if [ "$ALLOW_ORIGIN" != "$ORIGIN" ]; then
+            echo "❌ Invalid Access-Control-Allow-Origin: '$ALLOW_ORIGIN' (expected '$ORIGIN')"
+            exit 1
+          fi
+
+          if [ "$ALLOW_CREDENTIALS" != "true" ]; then
+            echo "❌ Invalid Access-Control-Allow-Credentials: '$ALLOW_CREDENTIALS' (expected 'true')"
+            exit 1
+          fi
+
+          echo "✅ CORS preflight returned expected headers"
+
       - name: Smoke Test Summary
         run: |
           echo "## Smoke Tests - Production" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ Health check passed" >> $GITHUB_STEP_SUMMARY
           echo "✅ API is responsive" >> $GITHUB_STEP_SUMMARY
+          echo "✅ CORS preflight check passed" >> $GITHUB_STEP_SUMMARY
           echo "✅ Production deployment verified" >> $GITHUB_STEP_SUMMARY
 
   notify-deployment:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -207,9 +207,36 @@ jobs:
             exit 1
           fi
 
+      - name: CORS Preflight Check
+        run: |
+          echo "Testing CORS preflight behavior..."
+          ORIGIN="https://staging.purposepath.app"
+          TARGET="${{ steps.api-url.outputs.url }}/api/v1/health"
+
+          CORS_HEADERS=$(curl -s -D - -o /dev/null -X OPTIONS "$TARGET" \
+            -H "Origin: $ORIGIN" \
+            -H "Access-Control-Request-Method: GET" \
+            -H "Access-Control-Request-Headers: Authorization,Content-Type")
+
+          ALLOW_ORIGIN=$(echo "$CORS_HEADERS" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-origin"{print $2}' | tail -n 1)
+          ALLOW_CREDENTIALS=$(echo "$CORS_HEADERS" | tr -d '\r' | awk -F': ' 'tolower($1)=="access-control-allow-credentials"{print $2}' | tail -n 1)
+
+          if [ "$ALLOW_ORIGIN" != "$ORIGIN" ]; then
+            echo "❌ Invalid Access-Control-Allow-Origin: '$ALLOW_ORIGIN' (expected '$ORIGIN')"
+            exit 1
+          fi
+
+          if [ "$ALLOW_CREDENTIALS" != "true" ]; then
+            echo "❌ Invalid Access-Control-Allow-Credentials: '$ALLOW_CREDENTIALS' (expected 'true')"
+            exit 1
+          fi
+
+          echo "✅ CORS preflight returned expected headers"
+
       - name: Smoke Test Summary
         run: |
           echo "## Smoke Tests - Staging" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ Health check passed" >> $GITHUB_STEP_SUMMARY
           echo "✅ API is responsive" >> $GITHUB_STEP_SUMMARY
+          echo "✅ CORS preflight check passed" >> $GITHUB_STEP_SUMMARY

--- a/coaching/pulumi/__main__.py
+++ b/coaching/pulumi/__main__.py
@@ -363,15 +363,13 @@ coaching_lambda = aws.lambda_.Function(
 )
 
 # API Gateway HTTP API
+# IMPORTANT: CORS is intentionally handled only in FastAPI middleware.
+# Keeping API Gateway CORS enabled created split-brain behavior where
+# preflight responses could come from APIGW ("*") while app responses came
+# from FastAPI (credential-aware origin regex), causing intermittent browser failures.
 api = aws.apigatewayv2.Api(
     "coaching-api",
     protocol_type="HTTP",
-    cors_configuration=aws.apigatewayv2.ApiCorsConfigurationArgs(
-        allow_origins=["*"],
-        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        allow_headers=["*"],
-        max_age=300,
-    ),
 )
 
 integration = aws.apigatewayv2.Integration(

--- a/coaching/pulumi/index.ts
+++ b/coaching/pulumi/index.ts
@@ -62,14 +62,12 @@ const coachingLambda = new aws.lambda.Function("coaching-api", {
     },
 });
 
+// IMPORTANT: CORS is intentionally handled only in FastAPI middleware.
+// Keeping API Gateway CORS enabled created split-brain behavior where
+// preflight responses could come from APIGW ("*") while app responses came
+// from FastAPI (credential-aware origin regex), causing intermittent browser failures.
 const api = new aws.apigatewayv2.Api("coaching-api", {
     protocolType: "HTTP",
-    corsConfiguration: {
-        allowOrigins: ["*"],
-        allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-        allowHeaders: ["*"],
-        maxAge: 300,
-    },
 });
 
 const integration = new aws.apigatewayv2.Integration("coaching-integration", {


### PR DESCRIPTION
## Summary
- Remove API Gateway HTTP API CORS config from coaching Pulumi so FastAPI is the single CORS authority
- Add CORS preflight smoke tests to dev, staging, and production deployment workflows
- Prevent recurrence where APIGW wildcard preflight headers conflict with credentialed FastAPI CORS responses

## Test plan
- [x] Verified code diff only touches CORS and workflow smoke checks
- [x] Confirmed no linter errors on edited files
- [ ] Merge this PR into `staging` and confirm `Deploy Staging` runs
- [ ] Verify staging preflight returns expected `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials: true`