### PR TITLE
fix(#252): migrate deprecated Gemini 3 preview endpoint

### DIFF
--- a/coaching/pyproject.toml
+++ b/coaching/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     
     # Google Gen AI SDK (replaces deprecated google-cloud-aiplatform for generative AI)
     # Migration: https://cloud.google.com/vertex-ai/generative-ai/docs/deprecations/genai-vertexai-sdk
-    "google-genai>=1.56.0",
+    "google-genai>=1.67.0",
 ]
 
 [project.optional-dependencies]

--- a/coaching/requirements.txt
+++ b/coaching/requirements.txt
@@ -31,7 +31,7 @@ langchain-anthropic==0.3.9
 langchain-aws==0.2.9
 langchain-openai==0.2.14
 langgraph==0.2.62
-google-genai==1.56.0
+google-genai==1.67.0
 
 # Redis - Latest version
 redis==6.4.0

--- a/coaching/scripts/test_google_vertex.py
+++ b/coaching/scripts/test_google_vertex.py
@@ -42,14 +42,14 @@ def check_prerequisites() -> bool:
 
     print(f"\n2. GOOGLE_PROJECT_ID: {project_id or '(will use credentials file)'}")
 
-    # Check if google-cloud-aiplatform is installed
+    # Check if google-genai is installed
     try:
-        import google.cloud.aiplatform  # noqa: F401
+        import google.genai  # noqa: F401
 
-        print("\n3. google-cloud-aiplatform: ✅ Installed")
+        print("\n3. google-genai: ✅ Installed")
     except ImportError:
-        print("\n3. google-cloud-aiplatform: ❌ NOT installed")
-        print("   Run: uv pip install google-cloud-aiplatform>=1.40.0")
+        print("\n3. google-genai: ❌ NOT installed")
+        print("   Run: uv pip install google-genai>=1.67.0")
         return False
 
     if not creds_path and not project_id:
@@ -72,7 +72,7 @@ async def test_gemini_model() -> None:
     print("=" * 60)
 
     project_id = os.getenv("GOOGLE_PROJECT_ID")
-    location = os.getenv("GOOGLE_VERTEX_LOCATION", "us-central1")
+    location = os.getenv("GOOGLE_VERTEX_LOCATION", "global")
 
     print("\nInitializing GoogleVertexLLMProvider...")
     print(f"  Project ID: {project_id or '(from credentials)'}")

--- a/coaching/src/core/llm_models.py
+++ b/coaching/src/core/llm_models.py
@@ -373,12 +373,12 @@ MODEL_REGISTRY: dict[str, SupportedModel] = {
         cost_per_1k_tokens=0.00025,  # Avg of $0.10/1M input, $0.40/1M output
         is_active=True,
     ),
-    # Gemini 3 Pro - Latest generation (Preview - December 2025)
+    # Gemini 3.1 Pro - Latest generation (Preview - February 2026)
     "GEMINI_3_PRO": SupportedModel(
         code="GEMINI_3_PRO",
         provider=LLMProvider.GOOGLE_VERTEX,
-        model_name="gemini-3-pro-preview",
-        version="3.0",
+        model_name="gemini-3.1-pro-preview",
+        version="3.1",
         provider_class="GoogleVertexLLMProvider",
         capabilities=[
             "chat",

--- a/coaching/src/infrastructure/llm/google_vertex_provider.py
+++ b/coaching/src/infrastructure/llm/google_vertex_provider.py
@@ -54,7 +54,7 @@ class GoogleVertexLLMProvider:
     Google Vertex AI adapter implementing LLMProviderPort.
 
     This adapter provides Google Vertex AI-backed LLM access using the new
-    google-genai SDK (v1.56.0+), implementing the provider port interface
+    google-genai SDK (v1.67.0+), implementing the provider port interface
     defined in the domain layer.
 
     Design:
@@ -72,7 +72,7 @@ class GoogleVertexLLMProvider:
     # Supported Vertex AI model IDs
     SUPPORTED_MODELS: ClassVar[list[str]] = [
         # Gemini 3.x Series (latest - December 2025)
-        "gemini-3-pro-preview",
+        "gemini-3.1-pro-preview",
         # Gemini 2.5 Series
         "gemini-2.5-pro",
         "gemini-2.5-flash",
@@ -141,7 +141,7 @@ class GoogleVertexLLMProvider:
             except ImportError as e:
                 raise ImportError(
                     "Google Gen AI SDK not installed. "
-                    "Install with: pip install google-genai>=1.56.0"
+                    "Install with: pip install google-genai>=1.67.0"
                 ) from e
 
             # Get project_id and credentials from Secrets Manager if not provided


### PR DESCRIPTION
## Summary
- Migrate deprecated Vertex endpoint usage from `gemini-3-pro-preview` to `gemini-3.1-pro-preview` in the model registry and Google Vertex provider allowlist.
- Upgrade `google-genai` dependency to current release (`1.67.0`) in both runtime and project dependency declarations.
- Refresh `coaching/scripts/test_google_vertex.py` to validate `google-genai` directly and default Vertex location to `global` for Gemini 3.1 model compatibility.

## Incident Context
Issue #252 tracks Google Cloud's retirement of `gemini-3-pro-preview`, which would cause runtime failures after endpoint removal if left unchanged.

## Online Research References
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-1-pro
- https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-flash
- https://pypi.org/project/google-genai/

## Validation
- [x] `uvx ruff check coaching/src/core/llm_models.py coaching/src/infrastructure/llm/google_vertex_provider.py coaching/scripts/test_google_vertex.py`
- [x] `uvx ruff format coaching/src/core/llm_models.py coaching/src/infrastructure/llm/google_vertex_provider.py coaching/scripts/test_google_vertex.py`
- [x] `uv run mypy coaching/src/core/llm_models.py coaching/src/infrastructure/llm/google_vertex_provider.py --explicit-package-bases`
- [x] `.venv\Scripts\python -m pytest coaching/tests/unit/infrastructure/llm/test_google_vertex_provider.py`
- [x] Preprod deployment + smoke tests: https://github.com/mottych/PurposePath_AI/actions/runs/23023408250
- [ ] Production post-deploy verification

Made with [Cursor](https://cursor.com)