### PR TITLE
feat(#302): EventBridge email insight kickoff from PurposePath_Api

### DIFF
--- a/coaching/pulumi/__main__.py
+++ b/coaching/pulumi/__main__.py
@@ -534,6 +534,36 @@ if stack_config.get("ai_async_jobs_enabled", "true").lower() == "true":
         source_arn=ai_job_executor_rule.arn,
     )
 
+    # PurposePath_Api → AI email_insight async kickoff (issue #302 / email-insights spec §3.3.1)
+    api_ai_job_requested_rule = aws.cloudwatch.EventRule(
+        "api-ai-job-requested-rule",
+        name=f"api-ai-job-requested-{stack}",
+        description="Triggers coaching Lambda when Api publishes ai.job.requested (email_insight kickoff)",
+        event_bus_name="default",
+        event_pattern=json.dumps(
+            {
+                "source": ["purposepath.api"],
+                "detail-type": ["ai.job.requested"],
+            }
+        ),
+        tags={"Environment": stack, "Service": "coaching-ai"},
+    )
+
+    aws.cloudwatch.EventTarget(
+        "api-ai-job-requested-target",
+        rule=api_ai_job_requested_rule.name,
+        arn=coaching_lambda.arn,
+        event_bus_name="default",
+    )
+
+    aws.lambda_.Permission(
+        "eventbridge-api-ai-kickoff-invoke-permission",
+        action="lambda:InvokeFunction",
+        function=coaching_lambda.name,
+        principal="events.amazonaws.com",
+        source_arn=api_ai_job_requested_rule.arn,
+    )
+
 # Parameter Store - Default Model Configuration
 # These parameters control default model codes for topic creation fallback
 default_basic_model_param = aws.ssm.Parameter(

--- a/coaching/src/api/handlers/eventbridge_handler.py
+++ b/coaching/src/api/handlers/eventbridge_handler.py
@@ -9,9 +9,13 @@ Supports:
 from __future__ import annotations
 
 import asyncio
+import json
 from typing import Any
 
 import structlog
+from coaching.src.api.models.ai_job_kickoff import ApiAiJobRequestedDetail
+from coaching.src.core.config_multitenant import settings
+from pydantic import ValidationError
 
 logger = structlog.get_logger()
 
@@ -99,6 +103,57 @@ async def handle_ai_job_created_event(event: dict[str, Any]) -> dict[str, Any]:
             "statusCode": 500,
             "body": f"Job execution failed: {e!s}",
         }
+
+
+async def handle_api_ai_job_requested_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Handle PurposePath_Api EventBridge kickoff for email_insight async jobs (#302)."""
+    raw_detail = event.get("detail", {})
+    if isinstance(raw_detail, str):
+        try:
+            detail_payload = json.loads(raw_detail)
+        except json.JSONDecodeError as e:
+            logger.error("eventbridge.api_kickoff.invalid_detail_json", error=str(e))
+            return {"statusCode": 400, "body": f"Invalid EventBridge detail JSON: {e!s}"}
+    elif isinstance(raw_detail, dict):
+        detail_payload = raw_detail
+    else:
+        return {"statusCode": 400, "body": "EventBridge detail must be object or JSON string"}
+
+    try:
+        parsed = ApiAiJobRequestedDetail.model_validate(detail_payload)
+    except ValidationError as e:
+        logger.warning("eventbridge.api_kickoff.validation_failed", errors=e.errors())
+        return {"statusCode": 400, "body": e.json()}
+
+    from coaching.src.api.dependencies.async_execution import get_async_execution_service
+    from coaching.src.services.async_execution_service import JobValidationError
+
+    try:
+        service = await get_async_execution_service()
+        await service.ingest_api_job_requested_event(parsed)
+        logger.info(
+            "eventbridge.api_kickoff.accepted",
+            job_id=parsed.job_id,
+            tenant_id=parsed.tenant_id,
+            topic_id=parsed.topic_id,
+        )
+        return {"statusCode": 200, "body": f"Job {parsed.job_id} kickoff accepted"}
+
+    except JobValidationError as e:
+        logger.warning(
+            "eventbridge.api_kickoff.validation_rejected",
+            job_id=parsed.job_id,
+            error=str(e),
+        )
+        return {"statusCode": 400, "body": str(e)}
+
+    except Exception as e:
+        logger.exception(
+            "eventbridge.api_kickoff.failed",
+            job_id=parsed.job_id,
+            error=str(e),
+        )
+        return {"statusCode": 500, "body": f"Kickoff processing failed: {e!s}"}
 
 
 async def handle_ai_message_created_event(event: dict[str, Any]) -> dict[str, Any]:
@@ -263,6 +318,12 @@ def handle_eventbridge_event(event: dict[str, Any], _context: Any) -> dict[str, 
         asyncio.set_event_loop(loop)
 
     # Route based on event type
+    if (
+        source == settings.ai_kickoff_event_source
+        and detail_type == settings.ai_kickoff_detail_type
+    ):
+        return loop.run_until_complete(handle_api_ai_job_requested_event(event))
+
     if source == "purposepath.ai" and detail_type == "ai.job.created":
         return loop.run_until_complete(handle_ai_job_created_event(event))
 

--- a/coaching/src/api/models/ai_job_kickoff.py
+++ b/coaching/src/api/models/ai_job_kickoff.py
@@ -1,0 +1,50 @@
+"""Pydantic models for PurposePath_Api EventBridge async job kickoff (issue #302)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from coaching.src.api.models.async_ai import AuthContext
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ApiAiJobRequestedDetail(BaseModel):
+    """EventBridge `detail` for `ai.job.requested` (email_insight kickoff).
+
+    Canonical fields align with docs/shared/Specifications/ai-api/email-insights-api-contract.md §3.4.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    event_id: str = Field(alias="eventId")
+    occurred_at_utc: datetime = Field(alias="occurredAtUtc")
+    source_service: str = Field(alias="sourceService")
+    schema_version: str = Field(alias="schemaVersion")
+    correlation_id: str = Field(alias="correlationId")
+    idempotency_key: str = Field(alias="idempotencyKey")
+    retry_attempt: int = Field(alias="retryAttempt")
+    tenant_id: str = Field(alias="tenantId")
+    user_id: str = Field(alias="userId")
+    topic_category: str = Field(alias="topicCategory")
+    topic_id: str = Field(alias="topicId")
+    event_signal: str = Field(alias="eventSignal")
+    locale: str
+    timezone: str
+    activity_data: dict[str, Any] = Field(alias="activityData")
+    auth_context: AuthContext = Field(alias="authContext")
+    job_id: str = Field(alias="jobId", min_length=1)
+    event_type: str = Field(alias="eventType", min_length=1)
+    kickoff_transport: Literal["eventbridge"] = Field(alias="kickoffTransport")
+    stage: str | None = Field(
+        default=None,
+        description="Optional environment gate; when set must match AI service stage",
+    )
+    causation_id: str | None = Field(default=None, alias="causationId")
+    metadata: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def validate_email_insight_category(self) -> ApiAiJobRequestedDetail:
+        if self.topic_category != "email_insight":
+            raise ValueError("topicCategory must be 'email_insight' for this kickoff contract")
+        return self

--- a/coaching/src/api/models/async_ai.py
+++ b/coaching/src/api/models/async_ai.py
@@ -7,6 +7,7 @@ execution endpoints (POST /ai/execute-async, GET /ai/jobs/{jobId}).
 from datetime import UTC, datetime
 from typing import Any
 
+from coaching.src.api.models.job_status_contract import api_contract_status_for_job_status
 from coaching.src.domain.entities.ai_job import AIJob
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -175,6 +176,8 @@ class AsyncJobCreatedResponse(BaseModel):
         data: Job details
     """
 
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
     success: bool = Field(default=True, description="Whether job creation succeeded")
     data: "AsyncJobData" = Field(..., description="Created job details")
 
@@ -189,23 +192,31 @@ class AsyncJobData(BaseModel):
         estimated_duration_ms: Estimated processing time
     """
 
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
     job_id: str = Field(
         ...,
+        alias="jobId",
+        serialization_alias="jobId",
         description="Unique job identifier for tracking",
         examples=["550e8400-e29b-41d4-a716-446655440000"],
     )
     status: str = Field(
         ...,
         description="Current job status",
-        examples=["pending"],
+        examples=["queued"],
     )
     topic_id: str = Field(
         ...,
+        alias="topicId",
+        serialization_alias="topicId",
         description="AI topic being executed",
         examples=["niche_review"],
     )
     estimated_duration_ms: int = Field(
         ...,
+        alias="estimatedDurationMs",
+        serialization_alias="estimatedDurationMs",
         description="Estimated processing time in milliseconds",
         examples=[30000],
     )
@@ -220,6 +231,8 @@ class JobStatusResponse(BaseModel):
         success: Always True for successful query
         data: Job status details
     """
+
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
 
     success: bool = Field(default=True, description="Whether query succeeded")
     data: "JobStatusData" = Field(..., description="Job status details")
@@ -243,16 +256,53 @@ class JobStatusData(BaseModel):
         estimated_duration_ms: Estimated processing time
     """
 
-    job_id: str = Field(..., description="Unique job identifier")
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
+    job_id: str = Field(
+        ...,
+        alias="jobId",
+        serialization_alias="jobId",
+        description="Unique job identifier",
+    )
     status: str = Field(..., description="Current job status")
-    topic_id: str = Field(..., description="AI topic being executed")
-    created_at: datetime = Field(..., description="Job creation timestamp")
-    completed_at: datetime | None = Field(None, description="Completion timestamp")
+    topic_id: str = Field(
+        ...,
+        alias="topicId",
+        serialization_alias="topicId",
+        description="AI topic being executed",
+    )
+    created_at: datetime = Field(
+        ...,
+        alias="createdAt",
+        serialization_alias="createdAt",
+        description="Job creation timestamp",
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        alias="completedAt",
+        serialization_alias="completedAt",
+        description="Completion timestamp",
+    )
     result: dict[str, Any] | None = Field(None, description="AI result (if completed)")
     error: str | None = Field(None, description="Error message (if failed)")
-    error_code: str | None = Field(None, description="Error code (if failed)")
-    processing_time_ms: int | None = Field(None, description="Actual processing time")
-    estimated_duration_ms: int = Field(30000, description="Estimated processing time")
+    error_code: str | None = Field(
+        default=None,
+        alias="errorCode",
+        serialization_alias="errorCode",
+        description="Error code (if failed)",
+    )
+    processing_time_ms: int | None = Field(
+        default=None,
+        alias="processingTimeMs",
+        serialization_alias="processingTimeMs",
+        description="Actual processing time",
+    )
+    estimated_duration_ms: int = Field(
+        default=30000,
+        alias="estimatedDurationMs",
+        serialization_alias="estimatedDurationMs",
+        description="Estimated processing time",
+    )
 
     @classmethod
     def from_job(cls, job: AIJob) -> "JobStatusData":
@@ -264,17 +314,19 @@ class JobStatusData(BaseModel):
         Returns:
             JobStatusData for API response
         """
-        return cls(
-            job_id=job.job_id,
-            status=job.status.value,
-            topic_id=job.topic_id,
-            created_at=job.created_at,
-            completed_at=job.completed_at,
-            result=job.result,
-            error=job.error,
-            error_code=job.error_code.value if job.error_code else None,
-            processing_time_ms=job.processing_time_ms,
-            estimated_duration_ms=job.estimated_duration_ms,
+        return cls.model_validate(
+            {
+                "jobId": job.job_id,
+                "status": api_contract_status_for_job_status(job.status),
+                "topicId": job.topic_id,
+                "createdAt": job.created_at,
+                "completedAt": job.completed_at,
+                "result": job.result,
+                "error": job.error,
+                "errorCode": job.error_code.value if job.error_code else None,
+                "processingTimeMs": job.processing_time_ms,
+                "estimatedDurationMs": job.estimated_duration_ms,
+            }
         )
 
 

--- a/coaching/src/api/models/job_status_contract.py
+++ b/coaching/src/api/models/job_status_contract.py
@@ -1,0 +1,17 @@
+"""Map internal AI job states to backend polling contract (email-insights spec §3.6)."""
+
+from __future__ import annotations
+
+from coaching.src.domain.entities.ai_job import AIJobStatus
+
+_STATUS_TO_API: dict[AIJobStatus, str] = {
+    AIJobStatus.PENDING: "queued",
+    AIJobStatus.PROCESSING: "running",
+    AIJobStatus.COMPLETED: "completed",
+    AIJobStatus.FAILED: "failed",
+}
+
+
+def api_contract_status_for_job_status(status: AIJobStatus) -> str:
+    """Return `data.status` value expected by PurposePath_Api pollers."""
+    return _STATUS_TO_API[status]

--- a/coaching/src/api/routes/ai_execute_async.py
+++ b/coaching/src/api/routes/ai_execute_async.py
@@ -21,6 +21,7 @@ from coaching.src.api.models.async_ai import (
     JobStatusResponse,
 )
 from coaching.src.api.models.auth import UserContext
+from coaching.src.api.models.job_status_contract import api_contract_status_for_job_status
 from coaching.src.services.async_execution_service import (
     AsyncAIExecutionService,
     JobNotFoundError,
@@ -46,6 +47,7 @@ async def get_optional_current_user(authorization: str | None = Header(None)) ->
 @router.post(
     "/execute-async",
     response_model=AsyncJobCreatedResponse,
+    response_model_by_alias=True,
     summary="Start an async AI job",
     description="""
 Start an asynchronous AI job for long-running operations.
@@ -188,7 +190,7 @@ async def execute_async(
             success=True,
             data=AsyncJobData(
                 job_id=job.job_id,
-                status=job.status.value,
+                status=api_contract_status_for_job_status(job.status),
                 topic_id=job.topic_id,
                 estimated_duration_ms=job.estimated_duration_ms,
             ),
@@ -227,6 +229,7 @@ async def execute_async(
 @router.get(
     "/jobs/{job_id}",
     response_model=JobStatusResponse,
+    response_model_by_alias=True,
     summary="Get job status",
     description="""
 Get the current status of an async AI job.

--- a/coaching/src/core/config_multitenant.py
+++ b/coaching/src/core/config_multitenant.py
@@ -166,6 +166,13 @@ class Settings(BaseSettings):
     session_ttl_hours: int = 24
     conversation_ttl_days: int = 30
     ai_async_jobs_enabled: bool = Field(default=True, validation_alias="AI_ASYNC_JOBS_ENABLED")
+    # EventBridge kickoff from PurposePath_Api (email_insight / issue #302); defaults per email-insights spec §3.3.1
+    ai_kickoff_event_source: str = Field(
+        default="purposepath.api", validation_alias="AI_KICKOFF_EVENT_SOURCE"
+    )
+    ai_kickoff_detail_type: str = Field(
+        default="ai.job.requested", validation_alias="AI_KICKOFF_DETAIL_TYPE"
+    )
 
     # LLM Configuration
     llm_temperature: float = 0.7

--- a/coaching/src/infrastructure/repositories/dynamodb_job_repository.py
+++ b/coaching/src/infrastructure/repositories/dynamodb_job_repository.py
@@ -72,6 +72,71 @@ class DynamoDBJobRepository:
             )
             raise
 
+    async def put_if_absent(self, job: AIJob) -> bool:
+        """Insert job only if job_id does not exist (idempotent kickoff).
+
+        Returns:
+            True if a new item was written, False if job_id already existed.
+        """
+        try:
+            item = self._to_dynamodb_item(job)
+            self.table.put_item(
+                Item=item,
+                ConditionExpression="attribute_not_exists(job_id)",
+            )
+            logger.info(
+                "ai_job.put_if_absent_inserted",
+                job_id=job.job_id,
+                tenant_id=job.tenant_id,
+            )
+            return True
+        except self.dynamodb.meta.client.exceptions.ConditionalCheckFailedException:
+            logger.info(
+                "ai_job.put_if_absent_exists",
+                job_id=job.job_id,
+                tenant_id=job.tenant_id,
+            )
+            return False
+        except Exception as e:
+            logger.error(
+                "ai_job.put_if_absent_failed",
+                job_id=job.job_id,
+                error=str(e),
+            )
+            raise
+
+    async def claim_pending_job(self, job_id: str) -> bool:
+        """Atomically transition job from pending to processing.
+
+        Returns:
+            True if this caller claimed the job, False if status was not pending.
+        """
+        try:
+            now = datetime.now(UTC).isoformat()
+            self.table.update_item(
+                Key={"job_id": job_id},
+                UpdateExpression="SET #st = :proc, started_at = :now",
+                ExpressionAttributeNames={"#st": "status"},
+                ExpressionAttributeValues={
+                    ":proc": AIJobStatus.PROCESSING.value,
+                    ":pending": AIJobStatus.PENDING.value,
+                    ":now": now,
+                },
+                ConditionExpression="#st = :pending",
+            )
+            logger.info("ai_job.claimed_for_processing", job_id=job_id)
+            return True
+        except self.dynamodb.meta.client.exceptions.ConditionalCheckFailedException:
+            logger.debug("ai_job.claim_skipped_not_pending", job_id=job_id)
+            return False
+        except Exception as e:
+            logger.error(
+                "ai_job.claim_failed",
+                job_id=job_id,
+                error=str(e),
+            )
+            raise
+
     async def get_by_id(self, job_id: str) -> AIJob | None:
         """Retrieve an AI job by ID.
 

--- a/coaching/src/services/async_execution_service.py
+++ b/coaching/src/services/async_execution_service.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import time
 from decimal import Decimal
 from typing import Any
+from uuid import uuid4
 
 import structlog
+from coaching.src.api.models.ai_job_kickoff import ApiAiJobRequestedDetail
 from coaching.src.application.ai_engine.unified_ai_engine import (
     ParameterValidationError,
     PromptRenderError,
@@ -18,7 +20,7 @@ from coaching.src.application.ai_engine.unified_ai_engine import (
     UnifiedAIEngine,
 )
 from coaching.src.application.llm_usage.llm_invocation_context import LlmInvocationContext
-from coaching.src.core.config import settings
+from coaching.src.core.config_multitenant import settings
 from coaching.src.core.constants import TopicCategory, TopicType
 from coaching.src.core.response_model_registry import get_response_model
 from coaching.src.core.topic_registry import (
@@ -110,6 +112,142 @@ class AsyncAIExecutionService:
         self._engine = ai_engine
         self._publisher = event_publisher
 
+    def _validate_and_build_pending_job(
+        self,
+        *,
+        job_id: str,
+        tenant_id: str,
+        user_id: str,
+        topic_id: str,
+        parameters: dict[str, Any],
+        jwt_token: str | None,
+        correlation_id: str | None,
+        idempotency_key: str | None,
+        event_id: str | None,
+    ) -> AIJob:
+        """Validate topic/params and build a pending AIJob (no persistence)."""
+        endpoint = get_topic_by_topic_id(topic_id)
+        if endpoint is None:
+            raise JobValidationError(f"Topic not found: {topic_id}")
+
+        if not endpoint.is_active:
+            raise JobValidationError(f"Topic is not active: {topic_id}")
+
+        if endpoint.topic_type != TopicType.SINGLE_SHOT:
+            raise JobValidationError(
+                f"Topic {topic_id} is type {endpoint.topic_type.value}, "
+                "only single-shot topics are supported for async execution"
+            )
+
+        required_params = get_required_parameter_names_for_topic(topic_id)
+        missing = [p for p in required_params if p not in parameters]
+        if missing:
+            raise JobValidationError(f"Missing required parameters for topic {topic_id}: {missing}")
+
+        response_model = get_response_model(endpoint.response_model)
+        if response_model is None:
+            raise JobValidationError(f"Response model not configured: {endpoint.response_model}")
+
+        estimated_duration = self._estimate_duration(topic_id)
+        job = AIJob(
+            job_id=job_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            topic_id=topic_id,
+            parameters=parameters,
+            jwt_token=jwt_token,
+            correlation_id=correlation_id,
+            idempotency_key=idempotency_key,
+            event_id=event_id,
+            status=AIJobStatus.PENDING,
+            estimated_duration_ms=estimated_duration,
+        )
+        job.set_ttl(hours=24)
+        return job
+
+    def _publish_job_created_trigger(self, job: AIJob) -> None:
+        """Publish `ai.job.created` so a separate Lambda invocation runs the worker."""
+        self._publisher.publish_ai_job_created(
+            job_id=job.job_id,
+            tenant_id=job.tenant_id,
+            user_id=job.user_id,
+            topic_id=job.topic_id,
+            parameters=job.parameters,
+            estimated_duration_ms=job.estimated_duration_ms,
+            correlation_id=job.correlation_id,
+            idempotency_key=job.idempotency_key,
+            event_id=job.event_id,
+        )
+
+    async def ingest_api_job_requested_event(self, detail: ApiAiJobRequestedDetail) -> None:
+        """Persist job from PurposePath_Api EventBridge kickoff and trigger async execution (#302)."""
+        if detail.stage is not None and detail.stage != settings.stage:
+            raise JobValidationError(
+                f"Event stage {detail.stage!r} does not match AI service stage {settings.stage!r}"
+            )
+
+        parameters = dict(detail.activity_data)
+        parameters.setdefault("locale", detail.locale)
+        parameters.setdefault("timezone", detail.timezone)
+
+        job = self._validate_and_build_pending_job(
+            job_id=detail.job_id,
+            tenant_id=detail.tenant_id,
+            user_id=detail.user_id,
+            topic_id=detail.topic_id,
+            parameters=parameters,
+            jwt_token=detail.auth_context.service_token,
+            correlation_id=detail.correlation_id,
+            idempotency_key=detail.idempotency_key,
+            event_id=detail.event_id,
+        )
+
+        inserted = await self._repository.put_if_absent(job)
+        if inserted:
+            logger.info(
+                "async_job.api_kickoff_inserted",
+                job_id=job.job_id,
+                tenant_id=job.tenant_id,
+                topic_id=job.topic_id,
+                correlation_id=job.correlation_id,
+                idempotency_key=job.idempotency_key,
+                event_id=job.event_id,
+            )
+            try:
+                self._publish_job_created_trigger(job)
+                logger.info(
+                    "async_job.api_kickoff_execution_triggered",
+                    job_id=job.job_id,
+                    topic_id=job.topic_id,
+                )
+            except EventBridgePublishError as e:
+                logger.error(
+                    "async_job.api_kickoff_trigger_failed",
+                    job_id=job.job_id,
+                    error=str(e),
+                )
+                await self._repository.update_status(
+                    job_id=job.job_id,
+                    status=AIJobStatus.FAILED,
+                    error=f"Failed to trigger execution: {e}",
+                    error_code=AIJobErrorCode.INTERNAL_ERROR,
+                )
+                raise JobValidationError(f"Failed to trigger job execution: {e}") from e
+            return
+
+        existing = await self._repository.get_by_id_for_tenant(job.job_id, job.tenant_id)
+        if existing is None:
+            raise JobValidationError(
+                f"Job id {job.job_id} already exists for a different tenant (isolation violation)"
+            )
+        if existing.status == AIJobStatus.PENDING:
+            logger.info(
+                "async_job.api_kickoff_idempotent_pending",
+                job_id=job.job_id,
+                tenant_id=job.tenant_id,
+            )
+            await self.execute_job_from_event(job_id=job.job_id, tenant_id=job.tenant_id)
+
     async def create_job(
         self,
         tenant_id: str,
@@ -142,49 +280,18 @@ class AsyncAIExecutionService:
         Raises:
             JobValidationError: If topic or parameters are invalid
         """
-        # Validate topic exists and is active
-        endpoint = get_topic_by_topic_id(topic_id)
-        if endpoint is None:
-            raise JobValidationError(f"Topic not found: {topic_id}")
-
-        if not endpoint.is_active:
-            raise JobValidationError(f"Topic is not active: {topic_id}")
-
-        # Validate topic is single-shot
-        if endpoint.topic_type != TopicType.SINGLE_SHOT:
-            raise JobValidationError(
-                f"Topic {topic_id} is type {endpoint.topic_type.value}, "
-                "only single-shot topics are supported for async execution"
-            )
-
-        # Validate required parameters
-        required_params = get_required_parameter_names_for_topic(topic_id)
-        missing = [p for p in required_params if p not in parameters]
-        if missing:
-            raise JobValidationError(f"Missing required parameters for topic {topic_id}: {missing}")
-
-        # Validate response model exists
-        response_model = get_response_model(endpoint.response_model)
-        if response_model is None:
-            raise JobValidationError(f"Response model not configured: {endpoint.response_model}")
-
-        # Create job
-        estimated_duration = self._estimate_duration(topic_id)
-        job = AIJob(
+        job = self._validate_and_build_pending_job(
+            job_id=str(uuid4()),
             tenant_id=tenant_id,
             user_id=user_id,
             topic_id=topic_id,
             parameters=parameters,
-            jwt_token=jwt_token,  # Store for enrichment during execution
+            jwt_token=jwt_token,
             correlation_id=correlation_id,
             idempotency_key=idempotency_key,
             event_id=event_id,
-            status=AIJobStatus.PENDING,
-            estimated_duration_ms=estimated_duration,
         )
-        job.set_ttl(hours=24)  # Auto-cleanup after 24 hours
 
-        # Save job
         await self._repository.save(job)
 
         logger.info(
@@ -198,27 +305,14 @@ class AsyncAIExecutionService:
             event_id=event_id,
         )
 
-        # Publish event to trigger async execution in separate Lambda invocation
-        # This ensures execution survives the current Lambda handler returning
         try:
-            self._publisher.publish_ai_job_created(
-                job_id=job.job_id,
-                tenant_id=tenant_id,
-                user_id=user_id,
-                topic_id=topic_id,
-                parameters=parameters,
-                estimated_duration_ms=estimated_duration,
-                correlation_id=correlation_id,
-                idempotency_key=idempotency_key,
-                event_id=event_id,
-            )
+            self._publish_job_created_trigger(job)
             logger.info(
                 "async_job.execution_triggered",
                 job_id=job.job_id,
                 topic_id=topic_id,
             )
         except EventBridgePublishError as e:
-            # If we can't publish, mark job as failed immediately
             logger.error(
                 "async_job.trigger_failed",
                 job_id=job.job_id,
@@ -261,12 +355,29 @@ class AsyncAIExecutionService:
             )
             raise JobNotFoundError(job_id)
 
-        # Check if job is still pending (not already processed)
         if job.status != AIJobStatus.PENDING:
             logger.warning(
                 "async_job.execute_from_event.already_processed",
                 job_id=job_id,
                 current_status=job.status.value,
+            )
+            return
+
+        if not await self._repository.claim_pending_job(job_id):
+            logger.info(
+                "async_job.execute_from_event.claim_lost",
+                job_id=job_id,
+                tenant_id=tenant_id,
+            )
+            return
+
+        job = await self._repository.get_by_id_for_tenant(job_id, tenant_id)
+        if job is None or job.status != AIJobStatus.PROCESSING:
+            logger.warning(
+                "async_job.execute_from_event.unexpected_after_claim",
+                job_id=job_id,
+                has_job=job is not None,
+                status=job.status.value if job else None,
             )
             return
 
@@ -277,8 +388,7 @@ class AsyncAIExecutionService:
             topic_id=job.topic_id,
         )
 
-        # Execute the job
-        await self._execute_job(job)
+        await self._execute_job(job, already_processing=True)
 
     async def get_job(
         self,
@@ -302,7 +412,7 @@ class AsyncAIExecutionService:
             raise JobNotFoundError(job_id)
         return job
 
-    async def _execute_job(self, job: AIJob) -> None:
+    async def _execute_job(self, job: AIJob, *, already_processing: bool = False) -> None:
         """Execute an AI job asynchronously.
 
         This method:
@@ -313,12 +423,13 @@ class AsyncAIExecutionService:
 
         Args:
             job: The job to execute
+            already_processing: When True, skip transition to processing (claim already applied)
         """
         start_time = time.time()
 
         try:
-            # Update status to processing
-            await self._repository.update_status(job.job_id, AIJobStatus.PROCESSING)
+            if not already_processing:
+                await self._repository.update_status(job.job_id, AIJobStatus.PROCESSING)
 
             # Publish started event
             try:

--- a/coaching/tests/unit/api/handlers/test_eventbridge_handler.py
+++ b/coaching/tests/unit/api/handlers/test_eventbridge_handler.py
@@ -1,5 +1,6 @@
 """Unit tests for EventBridge handler."""
 
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -180,6 +181,53 @@ class TestHandleEventBridgeEvent:
             result = handle_eventbridge_event(event, None)
 
         assert result["statusCode"] == 200
+
+    def test_routes_api_ai_job_requested(self) -> None:
+        """Api-published ai.job.requested should route to ingest handler."""
+        exp = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+        now = datetime.now(UTC).isoformat()
+        event: dict[str, Any] = {
+            "source": "purposepath.api",
+            "detail-type": "ai.job.requested",
+            "detail": {
+                "eventId": "e1",
+                "occurredAtUtc": now,
+                "sourceService": "PurposePath.NotificationProcessor.Lambda",
+                "schemaVersion": "2.0",
+                "correlationId": "c1",
+                "idempotencyKey": "i1",
+                "retryAttempt": 0,
+                "tenantId": "tenant-456",
+                "userId": "user-123",
+                "topicCategory": "email_insight",
+                "topicId": "goal_created_email_insight",
+                "eventSignal": "goal_created_email_insight",
+                "locale": "en-US",
+                "timezone": "UTC",
+                "activityData": {"goal_id": "goal-1"},
+                "authContext": {
+                    "serviceToken": "tok",
+                    "expiresAtUtc": exp,
+                    "issuer": "purposepath-api",
+                    "tokenType": "service_enrichment",
+                },
+                "jobId": "job-from-api",
+                "eventType": "goal_created_email_insight",
+                "kickoffTransport": "eventbridge",
+            },
+        }
+
+        mock_service = AsyncMock()
+        mock_service.ingest_api_job_requested_event.return_value = None
+
+        with patch(
+            "coaching.src.api.dependencies.async_execution.get_async_execution_service",
+            return_value=mock_service,
+        ):
+            result = handle_eventbridge_event(event, None)
+
+        assert result["statusCode"] == 200
+        mock_service.ingest_api_job_requested_event.assert_awaited_once()
 
     def test_unknown_event_type(self) -> None:
         """Test handling of unknown event types."""

--- a/coaching/tests/unit/api/models/test_job_status_contract.py
+++ b/coaching/tests/unit/api/models/test_job_status_contract.py
@@ -1,0 +1,18 @@
+"""Tests for backend polling status mapping."""
+
+import pytest
+from coaching.src.api.models.job_status_contract import api_contract_status_for_job_status
+from coaching.src.domain.entities.ai_job import AIJobStatus
+
+
+@pytest.mark.parametrize(
+    ("internal", "public"),
+    [
+        (AIJobStatus.PENDING, "queued"),
+        (AIJobStatus.PROCESSING, "running"),
+        (AIJobStatus.COMPLETED, "completed"),
+        (AIJobStatus.FAILED, "failed"),
+    ],
+)
+def test_api_contract_status_mapping(internal: AIJobStatus, public: str) -> None:
+    assert api_contract_status_for_job_status(internal) == public

--- a/coaching/tests/unit/services/test_async_execution_service.py
+++ b/coaching/tests/unit/services/test_async_execution_service.py
@@ -1,8 +1,10 @@
 """Unit tests for async execution service."""
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from coaching.src.api.models.ai_job_kickoff import ApiAiJobRequestedDetail
 from coaching.src.domain.entities.ai_job import AIJob, AIJobErrorCode, AIJobStatus
 from coaching.src.services.async_execution_service import (
     AsyncAIExecutionService,
@@ -19,6 +21,8 @@ class TestAsyncAIExecutionService:
     def mock_job_repository(self) -> AsyncMock:
         """Create mock job repository."""
         repo = AsyncMock()
+        repo.put_if_absent = AsyncMock(return_value=True)
+        repo.claim_pending_job = AsyncMock(return_value=True)
         return repo
 
     @pytest.fixture
@@ -241,7 +245,10 @@ class TestAsyncAIExecutionService:
             parameters={"current_value": "Test value"},
             status=AIJobStatus.PENDING,
         )
-        mock_job_repository.get_by_id_for_tenant.return_value = job
+        job_processing = job.model_copy(
+            update={"status": AIJobStatus.PROCESSING, "started_at": datetime.now(UTC)}
+        )
+        mock_job_repository.get_by_id_for_tenant.side_effect = [job, job_processing]
         mock_job_repository.update_status.return_value = None
 
         # Mock the endpoint registry
@@ -272,7 +279,8 @@ class TestAsyncAIExecutionService:
                 )
 
         # Assert
-        mock_job_repository.get_by_id_for_tenant.assert_called_once_with(job.job_id, "tenant_456")
+        assert mock_job_repository.get_by_id_for_tenant.await_count >= 2
+        mock_job_repository.claim_pending_job.assert_awaited_once_with(job.job_id)
         mock_ai_engine.execute_single_shot.assert_called_once()
         mock_eventbridge.publish_ai_job_completed.assert_called_once()
 
@@ -336,7 +344,10 @@ class TestAsyncAIExecutionService:
             status=AIJobStatus.PENDING,
             jwt_token=None,
         )
-        mock_job_repository.get_by_id_for_tenant.return_value = job
+        job_processing = job.model_copy(
+            update={"status": AIJobStatus.PROCESSING, "started_at": datetime.now(UTC)}
+        )
+        mock_job_repository.get_by_id_for_tenant.side_effect = [job, job_processing]
 
         with patch(
             "coaching.src.services.async_execution_service.get_topic_by_topic_id"
@@ -378,3 +389,77 @@ class TestAsyncAIExecutionService:
     ) -> None:
         """Auth/enrichment errors should map to deterministic taxonomy values."""
         assert service._map_auth_failure_error_code(error_message) == expected_error_code
+
+    @pytest.mark.asyncio
+    async def test_execute_job_from_event_claim_lost_skips_execution(
+        self,
+        service: AsyncAIExecutionService,
+        mock_job_repository: AsyncMock,
+        mock_ai_engine: AsyncMock,
+    ) -> None:
+        """If another worker claimed the job, this invocation should not run AI."""
+        job = AIJob(
+            user_id="user_123",
+            tenant_id="tenant_456",
+            topic_id="niche_review",
+            parameters={"current_value": "x"},
+            status=AIJobStatus.PENDING,
+        )
+        mock_job_repository.get_by_id_for_tenant.return_value = job
+        mock_job_repository.claim_pending_job.return_value = False
+
+        await service.execute_job_from_event(job_id=job.job_id, tenant_id="tenant_456")
+
+        mock_ai_engine.execute_single_shot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ingest_api_job_requested_inserts_and_publishes(
+        self,
+        service: AsyncAIExecutionService,
+        mock_job_repository: AsyncMock,
+        mock_eventbridge: MagicMock,
+    ) -> None:
+        """EventBridge kickoff should persist with backend job id and publish ai.job.created."""
+        from coaching.src.api.models.async_ai import AuthContext
+
+        mock_job_repository.put_if_absent.return_value = True
+        mock_eventbridge.publish_ai_job_created.return_value = "evt-1"
+
+        detail = ApiAiJobRequestedDetail(
+            event_id="evt-1",
+            occurred_at_utc=datetime.now(UTC),
+            source_service="PurposePath.NotificationProcessor.Lambda",
+            schema_version="2.0",
+            correlation_id="corr-1",
+            idempotency_key="idem-1",
+            retry_attempt=0,
+            tenant_id="tenant_456",
+            user_id="user_123",
+            topic_category="email_insight",
+            topic_id="goal_created_email_insight",
+            event_signal="goal_created_email_insight",
+            locale="en-US",
+            timezone="UTC",
+            activity_data={"goal_id": "goal_1"},
+            auth_context=AuthContext(
+                service_token="svc",
+                expires_at_utc=datetime.now(UTC) + timedelta(minutes=5),
+                issuer="purposepath-api",
+                token_type="service_enrichment",
+            ),
+            job_id="backend-job-id-1",
+            event_type="goal_created_email_insight",
+            kickoff_transport="eventbridge",
+        )
+
+        await service.ingest_api_job_requested_event(detail)
+
+        mock_job_repository.put_if_absent.assert_awaited_once()
+        written = mock_job_repository.put_if_absent.await_args.args[0]
+        assert written.job_id == "backend-job-id-1"
+        assert written.correlation_id == "corr-1"
+        assert written.idempotency_key == "idem-1"
+        assert written.event_id == "evt-1"
+        assert written.jwt_token == "svc"
+        mock_eventbridge.publish_ai_job_created.assert_called_once()
+        assert mock_eventbridge.publish_ai_job_created.call_args.kwargs["job_id"] == "backend-job-id-1"


### PR DESCRIPTION
## Summary
Implements AI-side EventBridge handshake for `email_insight` async jobs per [issue #302](https://github.com/mottych/PurposePath_AI/issues/302) and `email-insights-api-contract.md` §3.3–3.6.

## Changes
- Consume `purposepath.api` / `ai.job.requested` (env: `AI_KICKOFF_EVENT_SOURCE`, `AI_KICKOFF_DETAIL_TYPE`)
- Idempotent `put_if_absent` + `claim_pending_job` for safe duplicate delivery
- Pulumi: `api-ai-job-requested-{stack}` rule + Lambda permission
- API responses: camelCase + `queued`/`running` for status polling

## Deployment
Merging to `dev` triggers **Deploy Dev** workflow including **Pulumi `up`** for stack `dev`.

## Testing
- Unit tests updated/added; targeted pytest green locally.