### PR TITLE
fix: mypy AsyncJobData construction (unblock Deploy Dev)

### DIFF
--- a/coaching/src/api/routes/ai_execute_async.py
+++ b/coaching/src/api/routes/ai_execute_async.py
@@ -188,11 +188,13 @@ async def execute_async(
 
         return AsyncJobCreatedResponse(
             success=True,
-            data=AsyncJobData(
-                job_id=job.job_id,
-                status=api_contract_status_for_job_status(job.status),
-                topic_id=job.topic_id,
-                estimated_duration_ms=job.estimated_duration_ms,
+            data=AsyncJobData.model_validate(
+                {
+                    "jobId": job.job_id,
+                    "status": api_contract_status_for_job_status(job.status),
+                    "topicId": job.topic_id,
+                    "estimatedDurationMs": job.estimated_duration_ms,
+                }
             ),
         )
 


### PR DESCRIPTION
CI **Deploy Dev** failed on mypy after #303: `AsyncJobData` with alias fields rejects snake_case kwargs.

Use `model_validate` with camelCase payload (same pattern as `JobStatusData.from_job`).