### PR TITLE
fix(ci): Ruff isort known-first-party (unblock CI & deploy)

### DIFF
--- a/coaching/pyproject.toml
+++ b/coaching/pyproject.toml
@@ -134,6 +134,11 @@ ignore = [
     "N999",   # Invalid module name (triggered by repo path in CI)
 ]
 
+# Align with repo-root pyproject.toml so isort classifies coaching.* as first-party
+# when Ruff discovers this config (e.g. `ruff check` from coaching/).
+[tool.ruff.lint.isort]
+known-first-party = ["coaching", "shared"]
+
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "**/tests/**/*" = ["B011", "ARG001", "ARG002", "S101", "B007", "B017", "SIM118", "RUF043"]

--- a/coaching/src/api/dependencies/ai_engine.py
+++ b/coaching/src/api/dependencies/ai_engine.py
@@ -10,6 +10,8 @@ Design:
 
 import boto3
 import structlog
+from fastapi import Header
+
 from coaching.src.api.handlers.generic_ai_handler import GenericAIHandler
 from coaching.src.application.ai_engine.response_serializer import ResponseSerializer
 from coaching.src.application.ai_engine.unified_ai_engine import UnifiedAIEngine
@@ -25,7 +27,6 @@ from coaching.src.infrastructure.repositories.dynamodb_llm_usage_repository impo
 from coaching.src.repositories.topic_repository import TopicRepository
 from coaching.src.services.s3_prompt_storage import S3PromptStorage
 from coaching.src.services.template_parameter_processor import TemplateParameterProcessor
-from fastapi import Header
 from shared.services.aws_helpers import get_bedrock_client
 
 logger = structlog.get_logger()

--- a/coaching/src/api/dependencies/async_execution.py
+++ b/coaching/src/api/dependencies/async_execution.py
@@ -6,6 +6,7 @@ execution service and its components.
 
 import boto3
 import structlog
+
 from coaching.src.api.dependencies.ai_engine import get_unified_ai_engine
 from coaching.src.core.config_multitenant import settings
 from coaching.src.infrastructure.repositories.dynamodb_job_repository import DynamoDBJobRepository

--- a/coaching/src/api/dependencies/coaching_message_job.py
+++ b/coaching/src/api/dependencies/coaching_message_job.py
@@ -6,6 +6,7 @@ job service used in async message processing.
 
 import boto3
 import structlog
+
 from coaching.src.api.dependencies.ai_engine import (
     get_llm_usage_recording_service,
     get_provider_factory,

--- a/coaching/src/api/dependencies/sql_template_generation.py
+++ b/coaching/src/api/dependencies/sql_template_generation.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import boto3
 import structlog
+
 from coaching.src.core.config_multitenant import settings
 from coaching.src.integration.sql_template.cdata_mcp_client import (
     CDataMcpClient,

--- a/coaching/src/api/handlers/eventbridge_handler.py
+++ b/coaching/src/api/handlers/eventbridge_handler.py
@@ -13,9 +13,10 @@ import json
 from typing import Any
 
 import structlog
+from pydantic import ValidationError
+
 from coaching.src.api.models.ai_job_kickoff import ApiAiJobRequestedDetail
 from coaching.src.core.config_multitenant import settings
-from pydantic import ValidationError
 
 logger = structlog.get_logger()
 

--- a/coaching/src/api/handlers/generic_ai_handler.py
+++ b/coaching/src/api/handlers/generic_ai_handler.py
@@ -7,6 +7,9 @@ the UnifiedAIEngine, eliminating the need for endpoint-specific service classes.
 from typing import TYPE_CHECKING, Any
 
 import structlog
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+
 from coaching.src.api.models.auth import UserContext
 from coaching.src.application.ai_engine.response_serializer import SerializationError
 from coaching.src.application.ai_engine.unified_ai_engine import (
@@ -17,8 +20,6 @@ from coaching.src.application.ai_engine.unified_ai_engine import (
     UnifiedAIEngineError,
 )
 from coaching.src.core.topic_registry import get_endpoint_definition
-from fastapi import HTTPException, status
-from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from coaching.src.services.template_parameter_processor import TemplateParameterProcessor

--- a/coaching/src/api/legacy_dependencies.py
+++ b/coaching/src/api/legacy_dependencies.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import structlog
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.application.analysis.alignment_service import AlignmentAnalysisService
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
@@ -14,8 +15,11 @@ from coaching.src.application.analysis.measure_service import MeasureAnalysisSer
 from coaching.src.application.analysis.strategy_service import StrategyAnalysisService
 
 if TYPE_CHECKING:
-    from coaching.src.services.model_config_service import ModelConfigService
     from mypy_boto3_dynamodb import DynamoDBServiceResource
+
+    from coaching.src.services.model_config_service import ModelConfigService
+
+from fastapi import Depends
 
 from coaching.src.application.conversation.conversation_service import (
     ConversationApplicationService,
@@ -36,7 +40,6 @@ from coaching.src.services.insights_service import InsightsService
 from coaching.src.services.llm_template_service import LLMTemplateService
 from coaching.src.services.prompt_service import PromptService
 from coaching.src.services.s3_prompt_storage import S3PromptStorage
-from fastapi import Depends
 from shared.models.multitenant import RequestContext
 from shared.services.aws_helpers import (
     get_bedrock_client,

--- a/coaching/src/api/main.py
+++ b/coaching/src/api/main.py
@@ -7,6 +7,11 @@ from contextlib import asynccontextmanager
 from typing import Any
 
 import structlog
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from mangum import Mangum
+from starlette.middleware.base import BaseHTTPMiddleware
+
 from coaching.src.api.middleware import (
     ErrorHandlingMiddleware,
     LoggingMiddleware,
@@ -23,10 +28,6 @@ from coaching.src.api.routes import (
     multitenant_conversations,
 )
 from coaching.src.core.config_multitenant import settings
-from fastapi import FastAPI, Request, Response
-from fastapi.middleware.cors import CORSMiddleware
-from mangum import Mangum
-from starlette.middleware.base import BaseHTTPMiddleware
 
 # Configure Python logging for Lambda - Lambda captures stderr
 logging.basicConfig(

--- a/coaching/src/api/middleware/admin_auth.py
+++ b/coaching/src/api/middleware/admin_auth.py
@@ -1,8 +1,9 @@
 """Admin authentication and authorization middleware."""
 
 import structlog
-from coaching.src.api.auth import get_current_context
 from fastapi import Depends, HTTPException, status
+
+from coaching.src.api.auth import get_current_context
 from shared.models.multitenant import RequestContext, UserRole
 
 logger = structlog.get_logger()

--- a/coaching/src/api/middleware/error_handling.py
+++ b/coaching/src/api/middleware/error_handling.py
@@ -6,16 +6,17 @@ codes and error messages.
 """
 
 import structlog
-from coaching.src.domain.exceptions.base_exception import DomainException
-from coaching.src.domain.exceptions.conversation_exceptions import (
-    ConversationNotActive,
-    ConversationNotFound,
-)
 from fastapi import Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from coaching.src.domain.exceptions.base_exception import DomainException
+from coaching.src.domain.exceptions.conversation_exceptions import (
+    ConversationNotActive,
+    ConversationNotFound,
+)
 
 logger = structlog.get_logger()
 

--- a/coaching/src/api/models/ai_job_kickoff.py
+++ b/coaching/src/api/models/ai_job_kickoff.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from coaching.src.api.models.async_ai import AuthContext
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from coaching.src.api.models.async_ai import AuthContext
 
 
 class ApiAiJobRequestedDetail(BaseModel):

--- a/coaching/src/api/models/analysis.py
+++ b/coaching/src/api/models/analysis.py
@@ -7,8 +7,9 @@ including alignment, strategy, Measure, and operational analysis endpoints.
 from datetime import datetime
 from typing import Any
 
-from coaching.src.core.constants import AnalysisType
 from pydantic import BaseModel, Field, field_validator
+
+from coaching.src.core.constants import AnalysisType
 
 # Request Models
 

--- a/coaching/src/api/models/async_ai.py
+++ b/coaching/src/api/models/async_ai.py
@@ -7,9 +7,10 @@ execution endpoints (POST /ai/execute-async, GET /ai/jobs/{jobId}).
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
 from coaching.src.api.models.job_status_contract import api_contract_status_for_job_status
 from coaching.src.domain.entities.ai_job import AIJob
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AuthContext(BaseModel):

--- a/coaching/src/api/models/conversations.py
+++ b/coaching/src/api/models/conversations.py
@@ -7,8 +7,9 @@ These models handle API-layer concerns (serialization, validation, documentation
 from datetime import datetime
 from typing import Any
 
-from coaching.src.core.constants import CoachingTopic, ConversationStatus
 from pydantic import BaseModel, Field, field_validator
+
+from coaching.src.core.constants import CoachingTopic, ConversationStatus
 
 # Request Models
 

--- a/coaching/src/api/multitenant_dependencies.py
+++ b/coaching/src/api/multitenant_dependencies.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import structlog
 from fastapi import Depends
+
 from shared.services.aws_helpers import get_bedrock_client as get_bedrock_client_helper
 from shared.services.aws_helpers import get_dynamodb_resource
 from shared.services.aws_helpers import get_s3_client as get_s3_client_helper

--- a/coaching/src/api/routes/_archived/conversations.py
+++ b/coaching/src/api/routes/_archived/conversations.py
@@ -7,6 +7,8 @@ integrating with the Phase 4-6 application services and domain layer.
 from typing import cast
 
 import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+
 from coaching.src.api.auth import get_current_user
 from coaching.src.api.dependencies import (
     get_conversation_service,
@@ -36,7 +38,6 @@ from coaching.src.domain.exceptions.conversation_exceptions import (
     ConversationNotFound,
 )
 from coaching.src.domain.exceptions.topic_exceptions import TopicNotFoundError
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/conversations", tags=["conversations"])

--- a/coaching/src/api/routes/admin/health.py
+++ b/coaching/src/api/routes/admin/health.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime
 from typing import Literal
 
 import structlog
+from fastapi import APIRouter, Depends
+
 from coaching.src.api.dependencies import (
     get_topic_repository,
 )
@@ -24,7 +26,6 @@ from coaching.src.models.admin_topics import (
     ServiceStatuses,
 )
 from coaching.src.repositories.topic_repository import TopicRepository
-from fastapi import APIRouter, Depends
 from shared.models.schemas import ApiResponse
 from shared.services.aws_helpers import get_bedrock_client, get_s3_client
 

--- a/coaching/src/api/routes/admin/interactions.py
+++ b/coaching/src/api/routes/admin/interactions.py
@@ -6,6 +6,8 @@ Endpoint Usage Status:
 """
 
 import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.api.middleware.admin_auth import require_admin_access
 from coaching.src.core.llm_interactions import (
@@ -19,7 +21,6 @@ from coaching.src.models.admin_responses import (
     LLMInteractionInfo,
     LLMInteractionsResponse,
 )
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/api/routes/admin/llm_usage.py
+++ b/coaching/src/api/routes/admin/llm_usage.py
@@ -3,6 +3,9 @@
 from datetime import UTC, datetime
 
 import structlog
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.api.dependencies.ai_engine import get_llm_usage_repository
 from coaching.src.api.middleware.admin_auth import require_admin_access
@@ -15,8 +18,6 @@ from coaching.src.domain.entities.llm_usage_record import LlmUsageRecord
 from coaching.src.infrastructure.repositories.dynamodb_llm_usage_repository import (
     DynamoDBLlmUsageRepository,
 )
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/api/routes/admin/models.py
+++ b/coaching/src/api/routes/admin/models.py
@@ -8,6 +8,8 @@ Endpoint Usage Status:
 from typing import Any
 
 import structlog
+from fastapi import APIRouter, Body, Depends, HTTPException, Path
+
 from coaching.src.api.dependencies import get_model_config_service
 from coaching.src.api.middleware.admin_auth import require_admin_access
 from coaching.src.core.llm_models import LLMProvider, list_models
@@ -18,7 +20,6 @@ from coaching.src.models.admin_responses import (
 )
 from coaching.src.services.audit_log_service import AuditLogService
 from coaching.src.services.model_config_service import ModelConfigService
-from fastapi import APIRouter, Body, Depends, HTTPException, Path
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/api/routes/admin/prompts.py
+++ b/coaching/src/api/routes/admin/prompts.py
@@ -16,6 +16,8 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 import structlog
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
+
 from coaching.src.api.dependencies import get_s3_prompt_storage, get_topic_repository
 from coaching.src.api.middleware.admin_auth import require_admin_access
 from coaching.src.core.llm_models import DEFAULT_MODEL_CODE
@@ -38,7 +40,6 @@ from coaching.src.models.prompt_responses import (
 )
 from coaching.src.repositories.topic_repository import TopicRepository
 from coaching.src.services.s3_prompt_storage import S3PromptStorage
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/api/routes/admin/system_config.py
+++ b/coaching/src/api/routes/admin/system_config.py
@@ -8,12 +8,13 @@ Endpoint Usage:
 from typing import Any
 
 import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.api.models.auth import UserContext
 from coaching.src.core.llm_models import MODEL_REGISTRY
 from coaching.src.services.parameter_store_service import get_parameter_store_service
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
 
 logger = structlog.get_logger()
 

--- a/coaching/src/api/routes/admin/topics.py
+++ b/coaching/src/api/routes/admin/topics.py
@@ -23,6 +23,9 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
 import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
+from pydantic import BaseModel, Field
+
 from coaching.src.api.dependencies import (
     get_s3_prompt_storage,
     get_topic_repository,
@@ -90,8 +93,6 @@ from coaching.src.models.admin_topics import (
 )
 from coaching.src.repositories.topic_repository import TopicRepository
 from coaching.src.services.s3_prompt_storage import S3PromptStorage
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
-from pydantic import BaseModel, Field
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/api/routes/ai_execute.py
+++ b/coaching/src/api/routes/ai_execute.py
@@ -15,6 +15,8 @@ import time
 from typing import Any
 
 import structlog
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+
 from coaching.src.api.dependencies.ai_engine import get_unified_ai_engine
 from coaching.src.api.models.ai_execute import (
     GenericAIRequest,
@@ -42,7 +44,6 @@ from coaching.src.core.topic_registry import (
     get_topic_by_topic_id,
     list_all_topics,
 )
-from fastapi import APIRouter, Depends, HTTPException, Path, status
 
 logger = structlog.get_logger()
 

--- a/coaching/src/api/routes/ai_execute_async.py
+++ b/coaching/src/api/routes/ai_execute_async.py
@@ -11,6 +11,8 @@ API Gateway's 30-second timeout limit.
 """
 
 import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, status
+
 from coaching.src.api.auth import get_current_user, get_tenant_for_async_job_access
 from coaching.src.api.dependencies.async_execution import get_async_execution_service
 from coaching.src.api.models.async_ai import (
@@ -27,7 +29,6 @@ from coaching.src.services.async_execution_service import (
     JobNotFoundError,
     JobValidationError,
 )
-from fastapi import APIRouter, Depends, Header, HTTPException, Path, status
 
 logger = structlog.get_logger()
 

--- a/coaching/src/api/routes/analysis.py
+++ b/coaching/src/api/routes/analysis.py
@@ -18,6 +18,8 @@ This module provides REST API endpoints for various analysis types:
 from typing import cast
 
 import structlog
+from fastapi import APIRouter, Depends, status
+
 from coaching.src.api.auth import get_current_user
 from coaching.src.api.dependencies.ai_engine import (
     create_template_processor,
@@ -36,7 +38,6 @@ from coaching.src.api.models.analysis import (
     StrategyAnalysisResponse,
 )
 from coaching.src.api.models.auth import UserContext
-from fastapi import APIRouter, Depends, status
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/analysis", tags=["analysis"])

--- a/coaching/src/api/routes/business_data.py
+++ b/coaching/src/api/routes/business_data.py
@@ -3,6 +3,9 @@
 from typing import Generic, TypeVar, cast
 
 import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+
 from coaching.src.api.auth import get_current_user
 from coaching.src.api.dependencies.ai_engine import (
     create_template_processor,
@@ -15,8 +18,6 @@ from coaching.src.api.models.business_data import (
     BusinessMetricsRequest,
     BusinessMetricsResponse,
 )
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
 
 logger = structlog.get_logger(__name__)
 router = APIRouter(tags=["business-data"])

--- a/coaching/src/api/routes/coaching.py
+++ b/coaching/src/api/routes/coaching.py
@@ -10,11 +10,12 @@ Status: Safe to remove.
 """
 
 import structlog
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.models.requests import CoachingRequest
 from coaching.src.models.responses import CoachingResponse
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/api/routes/coaching_ai.py
+++ b/coaching/src/api/routes/coaching_ai.py
@@ -21,6 +21,8 @@ Migration Status:
 from typing import cast
 
 import structlog
+from fastapi import APIRouter, Depends, status
+
 from coaching.src.api.auth import get_current_user
 from coaching.src.api.dependencies.ai_engine import (
     create_template_processor,
@@ -45,7 +47,6 @@ from coaching.src.api.models.strategic_planning import (
     StrategySuggestionsRequest,
     StrategySuggestionsResponse,
 )
-from fastapi import APIRouter, Depends, status
 from shared.models.schemas import ApiResponse
 
 logger = structlog.get_logger()

--- a/coaching/src/api/routes/coaching_sessions.py
+++ b/coaching/src/api/routes/coaching_sessions.py
@@ -40,6 +40,9 @@ Error Responses:
 from typing import Any
 
 import structlog
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from pydantic import BaseModel, Field
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.api.dependencies.ai_engine import create_template_processor
 from coaching.src.api.multitenant_dependencies import (
@@ -79,8 +82,6 @@ from coaching.src.services.coaching_session_service import (
     TopicNotActiveError,
     TopicsWithStatusResponse,
 )
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from pydantic import BaseModel, Field
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse
 from shared.services.eventbridge_client import EventBridgePublisher

--- a/coaching/src/api/routes/health.py
+++ b/coaching/src/api/routes/health.py
@@ -10,10 +10,11 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
+from fastapi import APIRouter, Depends
+
 from coaching.src.api.multitenant_dependencies import get_redis_client
 from coaching.src.core.config_multitenant import settings
 from coaching.src.models.responses import HealthCheckResponse, ReadinessCheckResponse, ServiceStatus
-from fastapi import APIRouter, Depends
 from shared.models.schemas import ApiResponse
 from shared.services.aws_helpers import get_bedrock_client, get_s3_client
 

--- a/coaching/src/api/routes/insights.py
+++ b/coaching/src/api/routes/insights.py
@@ -9,6 +9,9 @@ Migration Status:
 from typing import cast
 
 import structlog
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
 from coaching.src.api.auth import get_current_context, get_current_user
 from coaching.src.api.dependencies import get_insights_service
 from coaching.src.api.dependencies.ai_engine import (
@@ -24,8 +27,6 @@ from coaching.src.models.responses import (
     InsightsSummaryResponse,
 )
 from coaching.src.services.insights_service import InsightsService
-from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
 from shared.models.multitenant import RequestContext
 from shared.models.schemas import ApiResponse, PaginatedResponse
 

--- a/coaching/src/api/routes/multitenant_conversations.py
+++ b/coaching/src/api/routes/multitenant_conversations.py
@@ -15,6 +15,8 @@ Migration target: /ai/coaching/* (coaching_sessions.py)
 from typing import Any
 
 import structlog
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
+
 from coaching.src.api.auth import get_current_context, require_admin
 from coaching.src.api.dependencies import get_conversation_repository
 from coaching.src.api.multitenant_dependencies import get_multitenant_conversation_service
@@ -33,7 +35,6 @@ from coaching.src.models.responses import (
     MessageResponse,
 )
 from coaching.src.services.multitenant_conversation_service import MultitenantConversationService
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 from shared.models.multitenant import CoachingTopic, RequestContext, UserRole
 from shared.models.schemas import ApiResponse
 

--- a/coaching/src/application/ai_engine/response_serializer.py
+++ b/coaching/src/application/ai_engine/response_serializer.py
@@ -9,8 +9,9 @@ import re
 from typing import Any, TypeVar
 
 import structlog
-from coaching.src.domain.entities.llm_topic import LLMTopic
 from pydantic import BaseModel, ValidationError
+
+from coaching.src.domain.entities.llm_topic import LLMTopic
 
 logger = structlog.get_logger()
 

--- a/coaching/src/application/analysis/alignment_service.py
+++ b/coaching/src/application/analysis/alignment_service.py
@@ -8,6 +8,7 @@ import json
 from typing import Any
 
 import structlog
+
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
 from coaching.src.core.constants import AnalysisType
 

--- a/coaching/src/application/analysis/base_analysis_service.py
+++ b/coaching/src/application/analysis/base_analysis_service.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import structlog
+
 from coaching.src.application.llm.llm_service import LLMApplicationService
 from coaching.src.core.constants import AnalysisType
 

--- a/coaching/src/application/analysis/kpi_service.py
+++ b/coaching/src/application/analysis/kpi_service.py
@@ -7,6 +7,7 @@ import json
 from typing import Any
 
 import structlog
+
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
 from coaching.src.core.constants import AnalysisType
 

--- a/coaching/src/application/analysis/measure_service.py
+++ b/coaching/src/application/analysis/measure_service.py
@@ -7,6 +7,7 @@ import json
 from typing import Any
 
 import structlog
+
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
 from coaching.src.core.constants import AnalysisType
 

--- a/coaching/src/application/analysis/operations_ai_service.py
+++ b/coaching/src/application/analysis/operations_ai_service.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import structlog
+
 from coaching.src.application.llm.llm_service import LLMApplicationService
 
 logger = structlog.get_logger()

--- a/coaching/src/application/analysis/strategy_service.py
+++ b/coaching/src/application/analysis/strategy_service.py
@@ -7,6 +7,7 @@ import json
 from typing import Any
 
 import structlog
+
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
 from coaching.src.core.constants import AnalysisType
 

--- a/coaching/src/application/analysis/strategy_suggestion_service.py
+++ b/coaching/src/application/analysis/strategy_suggestion_service.py
@@ -8,6 +8,7 @@ import json
 from typing import Any
 
 import structlog
+
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
 from coaching.src.core.constants import AnalysisType
 

--- a/coaching/src/application/conversation/conversation_service.py
+++ b/coaching/src/application/conversation/conversation_service.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
+
 from coaching.src.core.constants import CoachingTopic, ConversationStatus, MessageRole
 from coaching.src.core.types import ConversationId, TenantId, UserId
 from coaching.src.domain.entities.conversation import Conversation

--- a/coaching/src/application/enrichment/base_enrichment_service.py
+++ b/coaching/src/application/enrichment/base_enrichment_service.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 import structlog
+
 from coaching.src.infrastructure.cache.in_memory_cache import InMemoryCache
 
 logger = structlog.get_logger()

--- a/coaching/src/application/enrichment/business_context_enricher.py
+++ b/coaching/src/application/enrichment/business_context_enricher.py
@@ -6,6 +6,7 @@ Enriches analysis requests with business data from the Business API.
 from typing import Any
 
 import structlog
+
 from coaching.src.application.enrichment.base_enrichment_service import BaseEnrichmentService
 from coaching.src.infrastructure.external.business_api_client import BusinessApiClient
 

--- a/coaching/src/application/llm/llm_service.py
+++ b/coaching/src/application/llm/llm_service.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import structlog
+
 from coaching.src.domain.ports.llm_provider_port import (
     LLMMessage,
     LLMProviderPort,

--- a/coaching/src/application/llm_usage/llm_usage_recording_service.py
+++ b/coaching/src/application/llm_usage/llm_usage_recording_service.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime
 
 import structlog
+
 from coaching.src.application.llm_usage.llm_invocation_context import LlmInvocationContext
 from coaching.src.application.llm_usage.token_usage import normalize_token_counts
 from coaching.src.domain.entities.llm_topic import LLMTopic

--- a/coaching/src/application/llm_usage/llm_usage_summary.py
+++ b/coaching/src/application/llm_usage/llm_usage_summary.py
@@ -1,7 +1,8 @@
 """Aggregate metrics from usage rows (on-the-fly quota-oriented sums)."""
 
-from coaching.src.domain.entities.llm_usage_record import LlmUsageRecord
 from pydantic import BaseModel, Field
+
+from coaching.src.domain.entities.llm_usage_record import LlmUsageRecord
 
 
 class LlmUsageSummary(BaseModel):

--- a/coaching/src/application/prompt/prompt_service.py
+++ b/coaching/src/application/prompt/prompt_service.py
@@ -5,6 +5,7 @@ supporting both end-user consumption and admin UI management.
 """
 
 import structlog
+
 from coaching.src.core.constants import CoachingTopic
 from coaching.src.core.types import PromptTemplateId
 from coaching.src.domain.entities.prompt_template import PromptTemplate

--- a/coaching/src/core/config_multitenant.py
+++ b/coaching/src/core/config_multitenant.py
@@ -335,6 +335,7 @@ def get_google_vertex_credentials() -> dict[str, Any] | None:
     )
     try:
         import structlog
+
         from shared.services.aws_helpers import get_secretsmanager_client
 
         log = structlog.get_logger()

--- a/coaching/src/core/response_model_registry.py
+++ b/coaching/src/core/response_model_registry.py
@@ -12,6 +12,8 @@ Used by the generic AI execute endpoint to:
 from typing import Any
 
 import structlog
+from pydantic import BaseModel
+
 from coaching.src.api.models.analysis import (
     AlignmentAnalysisResponse,
     AlignmentExplanationResponse,
@@ -49,7 +51,6 @@ from coaching.src.models.responses import (
     InsightResponse,
     InsightsGenerationResponse,
 )
-from pydantic import BaseModel
 from shared.models.schemas import PaginatedResponse
 
 logger = structlog.get_logger()

--- a/coaching/src/core/retrieval_method_registry.py
+++ b/coaching/src/core/retrieval_method_registry.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import structlog
+
 from coaching.src.infrastructure.external.business_api_client import BusinessApiClient
 
 logger = structlog.get_logger()

--- a/coaching/src/domain/entities/analysis_request.py
+++ b/coaching/src/domain/entities/analysis_request.py
@@ -6,9 +6,10 @@ This module defines the AnalysisRequest for requesting business analysis.
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel, Field
+
 from coaching.src.core.constants import AnalysisType
 from coaching.src.core.types import AnalysisRequestId, ConversationId, UserId
-from pydantic import BaseModel, Field
 
 
 class AnalysisRequest(BaseModel):

--- a/coaching/src/domain/entities/coaching_session.py
+++ b/coaching/src/domain/entities/coaching_session.py
@@ -10,6 +10,8 @@ tracking conversation state, messages, and enforcing session lifecycle rules.
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from pydantic import BaseModel, Field, field_validator
+
 from coaching.src.core.constants import ConversationStatus, MessageRole
 from coaching.src.core.types import (
     SessionId,
@@ -22,7 +24,6 @@ from coaching.src.domain.exceptions import (
     SessionExpiredError,
     SessionNotActiveError,
 )
-from pydantic import BaseModel, Field, field_validator
 
 
 class CoachingMessage(BaseModel):

--- a/coaching/src/domain/entities/conversation.py
+++ b/coaching/src/domain/entities/conversation.py
@@ -7,6 +7,8 @@ business rules for coaching conversations.
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel, Field, field_validator
+
 from coaching.src.core.constants import (
     PHASE_PROGRESS_WEIGHTS,
     ConversationPhase,
@@ -18,7 +20,6 @@ from coaching.src.domain.value_objects.conversation_context import (
     ConversationContext,
 )
 from coaching.src.domain.value_objects.message import Message
-from pydantic import BaseModel, Field, field_validator
 
 
 class Conversation(BaseModel):

--- a/coaching/src/domain/entities/prompt_template.py
+++ b/coaching/src/domain/entities/prompt_template.py
@@ -11,9 +11,10 @@ import warnings
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel, Field, field_validator
+
 from coaching.src.core.constants import CoachingTopic
 from coaching.src.core.types import TemplateId
-from pydantic import BaseModel, Field, field_validator
 
 
 class PromptTemplate(BaseModel):

--- a/coaching/src/domain/events/analysis_events.py
+++ b/coaching/src/domain/events/analysis_events.py
@@ -4,9 +4,10 @@ This module contains all events related to analysis operations
 (alignment scoring, strategy recommendations, etc.).
 """
 
+from pydantic import Field
+
 from coaching.src.core.constants import AnalysisType
 from coaching.src.domain.events.base_event import DomainEvent
-from pydantic import Field
 
 
 class AnalysisRequested(DomainEvent):

--- a/coaching/src/domain/events/conversation_events.py
+++ b/coaching/src/domain/events/conversation_events.py
@@ -4,9 +4,10 @@ This module contains all events related to conversation lifecycle and interactio
 
 from datetime import datetime
 
+from pydantic import Field
+
 from coaching.src.core.constants import CoachingTopic, ConversationPhase, MessageRole
 from coaching.src.domain.events.base_event import DomainEvent
-from pydantic import Field
 
 
 class ConversationInitiated(DomainEvent):

--- a/coaching/src/domain/value_objects/conversation_context.py
+++ b/coaching/src/domain/value_objects/conversation_context.py
@@ -6,8 +6,9 @@ and progress of a coaching conversation.
 
 from typing import Any
 
-from coaching.src.core.constants import ConversationPhase
 from pydantic import BaseModel, Field, field_validator
+
+from coaching.src.core.constants import ConversationPhase
 
 
 class ConversationContext(BaseModel):

--- a/coaching/src/domain/value_objects/message.py
+++ b/coaching/src/domain/value_objects/message.py
@@ -7,9 +7,10 @@ a single message within a coaching conversation.
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel, Field, field_validator
+
 from coaching.src.core.constants import MessageRole
 from coaching.src.core.types import MessageId, create_message_id
-from pydantic import BaseModel, Field, field_validator
 
 
 class Message(BaseModel):

--- a/coaching/src/infrastructure/llm/bedrock_provider.py
+++ b/coaching/src/infrastructure/llm/bedrock_provider.py
@@ -34,6 +34,7 @@ from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
 import structlog
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage, LLMResponse
 
 logger = structlog.get_logger()

--- a/coaching/src/infrastructure/llm/google_vertex_provider.py
+++ b/coaching/src/infrastructure/llm/google_vertex_provider.py
@@ -27,6 +27,7 @@ from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
 import structlog
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage, LLMResponse
 
 logger = structlog.get_logger()
@@ -148,11 +149,12 @@ class GoogleVertexLLMProvider:
             project_id = self.project_id
             credentials = self.credentials
 
+            from google.oauth2 import service_account
+
             from coaching.src.core.config_multitenant import (
                 get_google_vertex_credentials,
                 get_settings,
             )
-            from google.oauth2 import service_account
 
             settings = get_settings()
 

--- a/coaching/src/infrastructure/llm/openai_provider.py
+++ b/coaching/src/infrastructure/llm/openai_provider.py
@@ -29,6 +29,7 @@ from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
 import structlog
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage, LLMResponse
 
 logger = structlog.get_logger()

--- a/coaching/src/infrastructure/llm/provider_factory.py
+++ b/coaching/src/infrastructure/llm/provider_factory.py
@@ -28,6 +28,7 @@ Related Issues:
 from typing import Any
 
 import structlog
+
 from coaching.src.core.config_multitenant import (
     Settings,
     get_google_vertex_credentials,

--- a/coaching/src/infrastructure/repositories/dynamodb_coaching_session_repository.py
+++ b/coaching/src/infrastructure/repositories/dynamodb_coaching_session_repository.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import structlog
 from boto3.dynamodb.conditions import Attr, Key
+
 from coaching.src.core.constants import ConversationStatus, MessageRole
 from coaching.src.core.types import SessionId, TenantId, UserId
 from coaching.src.domain.entities.coaching_session import (

--- a/coaching/src/infrastructure/repositories/dynamodb_conversation_repository.py
+++ b/coaching/src/infrastructure/repositories/dynamodb_conversation_repository.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import structlog
 from boto3.dynamodb.conditions import Attr, Key
+
 from coaching.src.core.constants import ConversationStatus
 from coaching.src.core.types import ConversationId, TenantId, UserId
 from coaching.src.domain.entities.conversation import Conversation

--- a/coaching/src/infrastructure/repositories/dynamodb_job_repository.py
+++ b/coaching/src/infrastructure/repositories/dynamodb_job_repository.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import structlog
 from boto3.dynamodb.conditions import Key
+
 from coaching.src.domain.entities.ai_job import AIJob, AIJobErrorCode, AIJobStatus, AIJobType
 
 logger = structlog.get_logger()

--- a/coaching/src/infrastructure/repositories/dynamodb_llm_usage_repository.py
+++ b/coaching/src/infrastructure/repositories/dynamodb_llm_usage_repository.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import structlog
 from boto3.dynamodb.conditions import Attr, Key
+
 from coaching.src.domain.entities.llm_usage_record import LlmUsageRecord
 
 logger = structlog.get_logger()

--- a/coaching/src/infrastructure/repositories/llm_config/template_metadata_repository.py
+++ b/coaching/src/infrastructure/repositories/llm_config/template_metadata_repository.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 
 import structlog
 from boto3.dynamodb.conditions import Attr, Key
+
 from coaching.src.core.llm_interactions import get_interaction
 from coaching.src.domain.entities.llm_config.template_metadata import TemplateMetadata
 

--- a/coaching/src/integration/sql_template/cdata_mcp_client.py
+++ b/coaching/src/integration/sql_template/cdata_mcp_client.py
@@ -7,6 +7,7 @@ from typing import Protocol
 
 import httpx
 import structlog
+
 from coaching.src.integration.sql_template.enums import ErrorCode, ErrorStage
 from coaching.src.integration.sql_template.errors import SqlTemplateGenerationError
 from coaching.src.integration.sql_template.models import DiscoveredColumn, RequestedDetail

--- a/coaching/src/integration/sql_template/idempotency.py
+++ b/coaching/src/integration/sql_template/idempotency.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Protocol
 
 from botocore.exceptions import ClientError
+
 from coaching.src.integration.sql_template.models import GenerationRecord
 
 

--- a/coaching/src/integration/sql_template/models.py
+++ b/coaching/src/integration/sql_template/models.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime
 from typing import Literal
 from uuid import UUID
 
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
 from coaching.src.integration.sql_template.enums import (
     AllowedOperator,
     ErrorCode,
@@ -15,7 +17,6 @@ from coaching.src.integration.sql_template.enums import (
     ValidationFailureCode,
     ValidationMethod,
 )
-from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class StrictModel(BaseModel):

--- a/coaching/src/integration/sql_template/service.py
+++ b/coaching/src/integration/sql_template/service.py
@@ -9,6 +9,7 @@ from typing import Protocol
 from uuid import uuid4
 
 import structlog
+
 from coaching.src.integration.sql_template.cdata_mcp_client import SchemaDiscoveryClient
 from coaching.src.integration.sql_template.enums import ErrorCode, ErrorStage, GenerationStatus
 from coaching.src.integration.sql_template.errors import SqlTemplateGenerationError, ValidationError

--- a/coaching/src/llm/workflow_orchestrator.py
+++ b/coaching/src/llm/workflow_orchestrator.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 import structlog
+
 from coaching.src.llm.providers.manager import provider_manager
 from coaching.src.workflows.base import WorkflowConfig, WorkflowState, WorkflowStatus, WorkflowType
 from coaching.src.workflows.orchestrator import WorkflowOrchestrator

--- a/coaching/src/models/admin_topics.py
+++ b/coaching/src/models/admin_topics.py
@@ -3,8 +3,9 @@
 from datetime import datetime
 from typing import Literal
 
-from coaching.src.core.constants import PromptType, TierLevel
 from pydantic import BaseModel, Field, field_validator
+
+from coaching.src.core.constants import PromptType, TierLevel
 
 # Conversation Config (for coaching topics only)
 

--- a/coaching/src/models/conversation.py
+++ b/coaching/src/models/conversation.py
@@ -3,9 +3,10 @@
 from datetime import UTC, datetime
 from typing import Any
 
+from pydantic import BaseModel, Field
+
 from coaching.src.core.constants import ConversationStatus, MessageRole
 from coaching.src.domain.value_objects.message import Message
-from pydantic import BaseModel, Field
 
 
 class ConversationContext(BaseModel):

--- a/coaching/src/models/enhanced_responses.py
+++ b/coaching/src/models/enhanced_responses.py
@@ -3,8 +3,9 @@
 from datetime import datetime
 from typing import Any
 
-from coaching.src.core.constants import ConversationStatus
 from pydantic import BaseModel, Field
+
+from coaching.src.core.constants import ConversationStatus
 from shared.models.base import BaseResponseModel
 
 

--- a/coaching/src/models/requests.py
+++ b/coaching/src/models/requests.py
@@ -2,8 +2,9 @@
 
 from typing import Any
 
-from coaching.src.core.constants import CoachingTopic
 from pydantic import BaseModel, Field, field_validator
+
+from coaching.src.core.constants import CoachingTopic
 
 
 class InitiateConversationRequest(BaseModel):

--- a/coaching/src/models/responses.py
+++ b/coaching/src/models/responses.py
@@ -4,8 +4,9 @@ import uuid
 from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
 
-from coaching.src.core.constants import ConversationPhase, ConversationStatus
 from pydantic import BaseModel, ConfigDict, Field
+
+from coaching.src.core.constants import ConversationPhase, ConversationStatus
 
 
 def _default_notification_preferences() -> dict[str, bool]:

--- a/coaching/src/scripts/seed_parameter_store.py
+++ b/coaching/src/scripts/seed_parameter_store.py
@@ -34,6 +34,7 @@ import argparse
 import sys
 
 import structlog
+
 from coaching.src.services.parameter_store_service import ParameterStoreService
 
 logger = structlog.get_logger()

--- a/coaching/src/scripts/seed_topics.py
+++ b/coaching/src/scripts/seed_topics.py
@@ -40,6 +40,7 @@ import sys
 
 import boto3
 import structlog
+
 from coaching.src.core.config_multitenant import settings
 from coaching.src.repositories.topic_repository import TopicRepository
 from coaching.src.services.s3_prompt_storage import S3PromptStorage

--- a/coaching/src/services/async_execution_service.py
+++ b/coaching/src/services/async_execution_service.py
@@ -13,6 +13,7 @@ from typing import Any
 from uuid import uuid4
 
 import structlog
+
 from coaching.src.api.models.ai_job_kickoff import ApiAiJobRequestedDetail
 from coaching.src.application.ai_engine.unified_ai_engine import (
     ParameterValidationError,

--- a/coaching/src/services/cache_service.py
+++ b/coaching/src/services/cache_service.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import Any
 
 import structlog
+
 from coaching.src.core.config import settings
 
 logger = structlog.get_logger()

--- a/coaching/src/services/coaching_message_job_service.py
+++ b/coaching/src/services/coaching_message_job_service.py
@@ -10,6 +10,7 @@ import time
 from typing import Any
 
 import structlog
+
 from coaching.src.core.types import ConversationId, TenantId, UserId
 from coaching.src.domain.entities.ai_job import AIJob, AIJobErrorCode, AIJobStatus, AIJobType
 from coaching.src.domain.exceptions.session_exceptions import (

--- a/coaching/src/services/coaching_session_service.py
+++ b/coaching/src/services/coaching_session_service.py
@@ -19,6 +19,8 @@ import re
 from typing import TYPE_CHECKING, Any
 
 import structlog
+from pydantic import BaseModel, Field
+
 from coaching.src.application.llm_usage.llm_invocation_context import LlmInvocationContext
 from coaching.src.application.llm_usage.llm_usage_recording_service import LlmUsageRecordingService
 from coaching.src.core.constants import ConversationStatus, MessageRole, TierLevel, TopicType
@@ -42,7 +44,6 @@ from coaching.src.domain.exceptions import (
     SessionNotFoundError,
 )
 from coaching.src.models.coaching_results import get_coaching_result_model
-from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     from coaching.src.domain.entities.llm_topic import LLMTopic

--- a/coaching/src/services/conversation_service.py
+++ b/coaching/src/services/conversation_service.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import structlog
+
 from coaching.src.core.constants import CoachingTopic
 from coaching.src.core.exceptions import ConversationNotFoundCompatError, ConversationNotFoundError
 from coaching.src.infrastructure.llm.model_pricing import calculate_cost

--- a/coaching/src/services/insights_service.py
+++ b/coaching/src/services/insights_service.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
+
 from coaching.src.infrastructure.external.business_api_client import BusinessApiClient
 from coaching.src.infrastructure.repositories.dynamodb_conversation_repository import (
     DynamoDBConversationRepository,

--- a/coaching/src/services/llm_service.py
+++ b/coaching/src/services/llm_service.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 import structlog
+
 from coaching.src.core.llm_models import DEFAULT_MODEL_ID
 from coaching.src.llm.providers.manager import ProviderManager
 from coaching.src.services.llm_service_adapter import LLMServiceAdapter

--- a/coaching/src/services/llm_service_adapter.py
+++ b/coaching/src/services/llm_service_adapter.py
@@ -9,6 +9,7 @@ multi-provider support and advanced workflow capabilities.
 from typing import Any, cast
 
 import structlog
+
 from coaching.src.core.llm_models import DEFAULT_MODEL_ID
 from coaching.src.llm.providers.manager import ProviderManager
 from coaching.src.workflows.base import WorkflowState, WorkflowType

--- a/coaching/src/services/llm_template_service.py
+++ b/coaching/src/services/llm_template_service.py
@@ -9,13 +9,14 @@ from typing import Any, cast
 
 import structlog
 from botocore.exceptions import ClientError
+from jinja2 import Template as Jinja2Template
+from jinja2 import TemplateSyntaxError as Jinja2SyntaxError
+
 from coaching.src.domain.entities.llm_config.template_metadata import TemplateMetadata
 from coaching.src.infrastructure.repositories.llm_config.template_metadata_repository import (
     TemplateMetadataRepository,
 )
 from coaching.src.services.cache_service import CacheService
-from jinja2 import Template as Jinja2Template
-from jinja2 import TemplateSyntaxError as Jinja2SyntaxError
 
 logger = structlog.get_logger()
 

--- a/coaching/src/services/model_config_service.py
+++ b/coaching/src/services/model_config_service.py
@@ -5,6 +5,7 @@ from typing import Any
 import structlog
 import yaml
 from botocore.exceptions import ClientError
+
 from coaching.src.domain.entities.model_config import ModelConfig
 
 logger = structlog.get_logger()

--- a/coaching/src/services/onboarding_service.py
+++ b/coaching/src/services/onboarding_service.py
@@ -1,6 +1,7 @@
 """Onboarding service for AI-powered onboarding assistance."""
 
 import structlog
+
 from coaching.src.services.llm_service import LLMService
 from coaching.src.services.website_analysis_service import WebsiteAnalysisService
 

--- a/coaching/src/services/parameter_gathering_service.py
+++ b/coaching/src/services/parameter_gathering_service.py
@@ -7,6 +7,7 @@ by making efficient API calls (one per source) and extracting individual values.
 from typing import Any
 
 import structlog
+
 from coaching.src.core.constants import ParameterSource
 from coaching.src.core.parameter_registry import PARAMETER_REGISTRY
 from coaching.src.core.topic_registry import (

--- a/coaching/src/services/prompt_service.py
+++ b/coaching/src/services/prompt_service.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Any
 
 import structlog
+
 from coaching.src.domain.entities.llm_topic import LLMTopic, ParameterDefinition
 from coaching.src.domain.exceptions.topic_exceptions import TopicNotFoundError
 from coaching.src.models.prompt import (

--- a/coaching/src/services/s3_prompt_storage.py
+++ b/coaching/src/services/s3_prompt_storage.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import boto3
 import structlog
 from botocore.exceptions import ClientError
+
 from coaching.src.domain.exceptions.topic_exceptions import S3StorageError
 
 if TYPE_CHECKING:

--- a/coaching/src/services/template_parameter_processor.py
+++ b/coaching/src/services/template_parameter_processor.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from typing import Any
 
 import structlog
+
 from coaching.src.core.parameter_registry import (
     ParameterDefinition,
     get_parameter_definition,

--- a/coaching/src/services/topic_seeding_service.py
+++ b/coaching/src/services/topic_seeding_service.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 import structlog
+
 from coaching.src.core.topic_registry import list_all_topics
 from coaching.src.core.topic_seed_data import TopicSeedData, get_seed_data_for_topic
 from coaching.src.domain.entities.llm_topic import LLMTopic, PromptInfo

--- a/coaching/src/services/user_limits_service.py
+++ b/coaching/src/services/user_limits_service.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import httpx
 import structlog
+
 from coaching.src.core.config_multitenant import get_settings
 
 logger = structlog.get_logger(__name__)

--- a/coaching/src/services/website_analysis_service.py
+++ b/coaching/src/services/website_analysis_service.py
@@ -11,6 +11,7 @@ import html2text
 import requests
 import structlog
 from bs4 import BeautifulSoup
+
 from coaching.src.llm.providers.manager import ProviderManager
 
 logger = structlog.get_logger()

--- a/coaching/src/workflows/analysis_workflow.py
+++ b/coaching/src/workflows/analysis_workflow.py
@@ -11,10 +11,11 @@ from datetime import datetime
 from typing import Any
 
 import structlog
-from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
-from coaching.src.core.constants import AnalysisType
 from langgraph.graph import StateGraph
 from pydantic import BaseModel, Field
+
+from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
+from coaching.src.core.constants import AnalysisType
 
 from .base import BaseWorkflow, WorkflowState, WorkflowStatus, WorkflowType
 

--- a/coaching/src/workflows/coaching_workflow.py
+++ b/coaching/src/workflows/coaching_workflow.py
@@ -10,6 +10,9 @@ from datetime import datetime
 from typing import Any
 
 import structlog
+from langgraph.graph import StateGraph
+from pydantic import BaseModel, Field
+
 from coaching.src.application.conversation.conversation_service import (
     ConversationApplicationService,
 )
@@ -17,8 +20,6 @@ from coaching.src.application.llm.llm_service import LLMApplicationService
 from coaching.src.core.constants import CoachingTopic, MessageRole
 from coaching.src.core.types import ConversationId, TenantId, UserId
 from coaching.src.domain.ports.llm_provider_port import LLMMessage
-from langgraph.graph import StateGraph
-from pydantic import BaseModel, Field
 
 from .base import BaseWorkflow, WorkflowState, WorkflowStatus, WorkflowType
 

--- a/coaching/tests/e2e/test_google_vertex_e2e.py
+++ b/coaching/tests/e2e/test_google_vertex_e2e.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+
 from coaching.src.core.config_multitenant import get_google_vertex_credentials, get_settings
 from coaching.src.domain.ports.llm_provider_port import LLMMessage
 from coaching.src.infrastructure.llm.google_vertex_provider import GoogleVertexLLMProvider

--- a/coaching/tests/e2e/test_inference_profile_models.py
+++ b/coaching/tests/e2e/test_inference_profile_models.py
@@ -5,6 +5,7 @@ for newer Claude models that require region-prefixed model IDs.
 """
 
 import pytest
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage
 from coaching.src.infrastructure.llm.bedrock_provider import BedrockLLMProvider
 

--- a/coaching/tests/e2e/test_llm_providers_e2e.py
+++ b/coaching/tests/e2e/test_llm_providers_e2e.py
@@ -10,6 +10,7 @@ Tests direct provider calls to validate:
 import os
 
 import pytest
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage
 from coaching.src.infrastructure.llm.bedrock_provider import BedrockLLMProvider
 from coaching.src.infrastructure.llm.google_vertex_provider import GoogleVertexLLMProvider

--- a/coaching/tests/integration/api/test_analysis.py
+++ b/coaching/tests/integration/api/test_analysis.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi.testclient import TestClient
+
 from coaching.src.api.dependencies.ai_engine import get_generic_handler
 from coaching.src.api.main import app
 from coaching.src.api.models.analysis import (
@@ -17,7 +19,6 @@ from coaching.src.api.models.analysis import (
     StrategyAnalysisResponse,
 )
 from coaching.src.core.constants import AnalysisType
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture

--- a/coaching/tests/integration/api/test_coaching_sessions.py
+++ b/coaching/tests/integration/api/test_coaching_sessions.py
@@ -7,6 +7,8 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi.testclient import TestClient
+
 from coaching.src.api.main import app
 from coaching.src.api.routes.coaching_sessions import (
     get_coaching_session_repository,
@@ -26,7 +28,6 @@ from coaching.src.services.coaching_session_service import (
     TopicStatus,
     TopicsWithStatusResponse,
 )
-from fastapi.testclient import TestClient
 
 # =============================================================================
 # Fixtures

--- a/coaching/tests/integration/api/test_conversations.py
+++ b/coaching/tests/integration/api/test_conversations.py
@@ -7,6 +7,8 @@ application services, domain entities, and auth-based context.
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi.testclient import TestClient
+
 from coaching.src.api.dependencies import get_conversation_repository, get_conversation_service
 from coaching.src.api.dependencies.ai_engine import get_generic_handler
 from coaching.src.api.main import app
@@ -20,7 +22,6 @@ from coaching.src.models.responses import (
     ConversationSummary,
     MessageResponse,
 )
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture

--- a/coaching/tests/integration/test_api.py
+++ b/coaching/tests/integration/test_api.py
@@ -3,8 +3,9 @@
 from typing import Any
 
 import pytest
-from coaching.src.api.main import app
 from fastapi.testclient import TestClient
+
+from coaching.src.api.main import app
 
 
 @pytest.fixture

--- a/coaching/tests/integration/test_business_api_integration.py
+++ b/coaching/tests/integration/test_business_api_integration.py
@@ -23,6 +23,7 @@ from typing import Any
 import httpx
 import pytest
 import structlog
+
 from coaching.src.infrastructure.external.business_api_client import BusinessApiClient
 
 logger = structlog.get_logger()

--- a/coaching/tests/integration/test_conversation_with_topics_e2e.py
+++ b/coaching/tests/integration/test_conversation_with_topics_e2e.py
@@ -6,6 +6,7 @@ Tests complete conversation flows using topics instead of hardcoded prompts.
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.core.constants import ConversationPhase, ConversationStatus
 from coaching.src.domain.entities.conversation import Conversation
 from coaching.src.domain.entities.llm_topic import LLMTopic, PromptInfo

--- a/coaching/tests/integration/test_sql_template_generation_integration.py
+++ b/coaching/tests/integration/test_sql_template_generation_integration.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 import pytest
+
 from coaching.src.integration.sql_template.cdata_mcp_client import CDataMcpClient
 from coaching.src.integration.sql_template.enums import ErrorCode
 from coaching.src.integration.sql_template.errors import SqlTemplateGenerationError

--- a/coaching/tests/integration/test_topic_system_e2e.py
+++ b/coaching/tests/integration/test_topic_system_e2e.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
+
 from coaching.src.domain.entities.llm_topic import LLMTopic, PromptInfo
 from coaching.src.repositories.topic_repository import TopicRepository
 from coaching.src.services.prompt_service import PromptService

--- a/coaching/tests/integration/test_unified_ai_engine.py
+++ b/coaching/tests/integration/test_unified_ai_engine.py
@@ -9,6 +9,7 @@ This module tests the topic-driven endpoint architecture including:
 """
 
 import pytest
+
 from coaching.src.application.ai_engine.unified_ai_engine import UnifiedAIEngine
 from coaching.src.core.topic_registry import (
     ENDPOINT_REGISTRY,

--- a/coaching/tests/performance/test_api_performance.py
+++ b/coaching/tests/performance/test_api_performance.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 from httpx import AsyncClient
+
 from shared.observability.performance import measure_time
 
 

--- a/coaching/tests/test_business_data_api.py
+++ b/coaching/tests/test_business_data_api.py
@@ -5,12 +5,13 @@ Tests for coaching business-data endpoint with ApiResponse envelope.
 from unittest.mock import Mock, patch
 
 import pytest
+from fastapi.testclient import TestClient
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.api.main import app
 from coaching.src.api.multitenant_dependencies import (
     get_multitenant_conversation_service,
 )
-from fastapi.testclient import TestClient
 from shared.models.multitenant import (
     Permission,
     RequestContext,

--- a/coaching/tests/test_langgraph_workflows.py
+++ b/coaching/tests/test_langgraph_workflows.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from coaching.src.llm.workflow_orchestrator import (
     AdvancedStateManager,
     LangGraphWorkflowOrchestrator,

--- a/coaching/tests/test_llm_service_refactoring.py
+++ b/coaching/tests/test_llm_service_refactoring.py
@@ -13,6 +13,7 @@ from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
+
 from coaching.src.models.llm_models import LLMResponse
 from coaching.src.services.llm_service import LLMService
 from coaching.src.services.llm_service_adapter import LLMServiceAdapter

--- a/coaching/tests/unit/api/handlers/test_eventbridge_handler.py
+++ b/coaching/tests/unit/api/handlers/test_eventbridge_handler.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
 from coaching.src.api.handlers.eventbridge_handler import (
     handle_ai_job_created_event,
     handle_eventbridge_event,

--- a/coaching/tests/unit/api/models/test_async_ai.py
+++ b/coaching/tests/unit/api/models/test_async_ai.py
@@ -3,8 +3,9 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from coaching.src.api.models.async_ai import AsyncAIRequest
 from pydantic import ValidationError
+
+from coaching.src.api.models.async_ai import AsyncAIRequest
 
 pytestmark = pytest.mark.unit
 

--- a/coaching/tests/unit/api/models/test_job_status_contract.py
+++ b/coaching/tests/unit/api/models/test_job_status_contract.py
@@ -1,6 +1,7 @@
 """Tests for backend polling status mapping."""
 
 import pytest
+
 from coaching.src.api.models.job_status_contract import api_contract_status_for_job_status
 from coaching.src.domain.entities.ai_job import AIJobStatus
 

--- a/coaching/tests/unit/api/models/test_strategic_planning.py
+++ b/coaching/tests/unit/api/models/test_strategic_planning.py
@@ -5,6 +5,8 @@ Reference: Issue #182
 """
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.api.models.strategic_planning import (
     ActionSuggestion,
     ActionSuggestionsData,
@@ -19,7 +21,6 @@ from coaching.src.api.models.strategic_planning import (
     StrategySuggestionsResponse,
     SuggestedTarget,
 )
-from pydantic import ValidationError
 
 
 @pytest.mark.unit

--- a/coaching/tests/unit/api/routes/admin/test_prompts.py
+++ b/coaching/tests/unit/api/routes/admin/test_prompts.py
@@ -2,13 +2,14 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
 from coaching.src.api.dependencies import get_s3_prompt_storage, get_topic_repository
 from coaching.src.api.middleware.admin_auth import require_admin_access
 from coaching.src.api.routes.admin.prompts import router
 from coaching.src.domain.entities.llm_topic import LLMTopic
 from coaching.src.domain.exceptions.topic_exceptions import DuplicateTopicError
-from fastapi import FastAPI, status
-from fastapi.testclient import TestClient
 from shared.models.multitenant import RequestContext, UserRole
 
 # Setup app

--- a/coaching/tests/unit/api/routes/test_ai_execute.py
+++ b/coaching/tests/unit/api/routes/test_ai_execute.py
@@ -7,6 +7,9 @@ schema discovery (GET /ai/schemas), and topic listing (GET /ai/topics).
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
 from coaching.src.api.main import app
 from coaching.src.api.models.ai_execute import (
     GenericAIRequest,
@@ -17,8 +20,6 @@ from coaching.src.api.models.ai_execute import (
 )
 from coaching.src.core.constants import TopicCategory, TopicType
 from coaching.src.core.topic_registry import TopicDefinition
-from fastapi import status
-from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.unit
 

--- a/coaching/tests/unit/api/routes/test_ai_execute_async.py
+++ b/coaching/tests/unit/api/routes/test_ai_execute_async.py
@@ -4,9 +4,10 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi.testclient import TestClient
+
 from coaching.src.api.main import app
 from coaching.src.domain.entities.ai_job import AIJob
-from fastapi.testclient import TestClient
 
 pytestmark = pytest.mark.unit
 

--- a/coaching/tests/unit/api/routes/test_coaching_sessions_async.py
+++ b/coaching/tests/unit/api/routes/test_coaching_sessions_async.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+
 from coaching.src.api.routes.coaching_sessions import get_message_job_status
 from coaching.src.domain.entities.ai_job import AIJob, AIJobStatus, AIJobType
 from shared.models.multitenant import RequestContext, UserRole

--- a/coaching/tests/unit/api/test_admin_topics.py
+++ b/coaching/tests/unit/api/test_admin_topics.py
@@ -4,6 +4,9 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from coaching.src.api.auth import get_current_context
 from coaching.src.api.dependencies import (
     get_s3_prompt_storage,
@@ -14,8 +17,6 @@ from coaching.src.api.middleware.admin_auth import require_admin_access
 from coaching.src.api.routes.admin.topics import router
 from coaching.src.domain.entities.llm_topic import LLMTopic, PromptInfo
 from coaching.src.domain.entities.llm_usage_record import LlmUsageRecord
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from shared.models.multitenant import RequestContext, UserRole
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/application/ai_engine/test_unified_ai_engine.py
+++ b/coaching/tests/unit/application/ai_engine/test_unified_ai_engine.py
@@ -1,6 +1,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic import BaseModel
+
 from coaching.src.application.ai_engine.response_serializer import ResponseSerializer
 from coaching.src.application.ai_engine.unified_ai_engine import (
     ParameterValidationError,
@@ -19,7 +21,6 @@ from coaching.src.domain.value_objects.conversation_context import ConversationC
 from coaching.src.infrastructure.llm.provider_factory import LLMProviderFactory
 from coaching.src.repositories.topic_repository import TopicRepository
 from coaching.src.services.s3_prompt_storage import S3PromptStorage
-from pydantic import BaseModel
 
 
 class SampleResponseModel(BaseModel):

--- a/coaching/tests/unit/application/analysis/test_operations_ai_service.py
+++ b/coaching/tests/unit/application/analysis/test_operations_ai_service.py
@@ -9,6 +9,7 @@ Tests all three service methods with mocked LLM service:
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from coaching.src.application.analysis.operations_ai_service import OperationsAIService
 
 

--- a/coaching/tests/unit/application/analysis/test_strategy_suggestion_service.py
+++ b/coaching/tests/unit/application/analysis/test_strategy_suggestion_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 from coaching.src.application.analysis.strategy_suggestion_service import StrategySuggestionService
 from coaching.src.application.llm.llm_service import LLMApplicationService
 from coaching.src.core.constants import AnalysisType

--- a/coaching/tests/unit/application/conversation/test_conversation_application_service.py
+++ b/coaching/tests/unit/application/conversation/test_conversation_application_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+
 from coaching.src.application.conversation.conversation_service import (
     ConversationApplicationService,
 )

--- a/coaching/tests/unit/application/llm/test_llm_application_service.py
+++ b/coaching/tests/unit/application/llm/test_llm_application_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+
 from coaching.src.application.llm.llm_service import LLMApplicationService
 from coaching.src.domain.ports.llm_provider_port import LLMMessage, LLMProviderPort, LLMResponse
 

--- a/coaching/tests/unit/application/llm_usage/test_billing_periods.py
+++ b/coaching/tests/unit/application/llm_usage/test_billing_periods.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.application.llm_usage.billing_periods import months_in_range
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/application/prompt/test_prompt_application_service.py
+++ b/coaching/tests/unit/application/prompt/test_prompt_application_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from coaching.src.application.prompt.prompt_service import PromptApplicationService
 from coaching.src.core.constants import CoachingTopic
 from coaching.src.domain.entities.prompt_template import PromptTemplate

--- a/coaching/tests/unit/core/test_deprecation.py
+++ b/coaching/tests/unit/core/test_deprecation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from coaching.src.core.deprecation import deprecated
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/core/test_interaction_codes.py
+++ b/coaching/tests/unit/core/test_interaction_codes.py
@@ -1,4 +1,5 @@
 import pytest
+
 from coaching.src.core import interaction_codes
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/core/test_llm_interactions.py
+++ b/coaching/tests/unit/core/test_llm_interactions.py
@@ -1,6 +1,7 @@
 """Unit tests for LLM Interactions Registry."""
 
 import pytest
+
 from coaching.src.core.llm_interactions import (
     INTERACTION_REGISTRY,
     InteractionCategory,

--- a/coaching/tests/unit/core/test_llm_models.py
+++ b/coaching/tests/unit/core/test_llm_models.py
@@ -1,6 +1,7 @@
 """Unit tests for LLM Models Registry."""
 
 import pytest
+
 from coaching.src.core.llm_models import (
     MODEL_REGISTRY,
     LLMProvider,

--- a/coaching/tests/unit/core/test_parameter_registry.py
+++ b/coaching/tests/unit/core/test_parameter_registry.py
@@ -10,6 +10,7 @@ Key architectural decisions:
 """
 
 import pytest
+
 from coaching.src.core.parameter_registry import (
     PARAMETER_REGISTRY,
     ParameterDefinition,

--- a/coaching/tests/unit/core/test_retrieval_goal_scoped_enrichment.py
+++ b/coaching/tests/unit/core/test_retrieval_goal_scoped_enrichment.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+
 from coaching.src.core.retrieval_method_registry import (
     RetrievalContext,
     get_all_strategies,

--- a/coaching/tests/unit/core/test_topic_seed_data.py
+++ b/coaching/tests/unit/core/test_topic_seed_data.py
@@ -1,4 +1,5 @@
 import pytest
+
 from coaching.src.core.constants import TopicCategory, TopicType
 from coaching.src.core.topic_seed_data import TOPIC_SEED_DATA, TopicSeedData
 

--- a/coaching/tests/unit/core/test_types.py
+++ b/coaching/tests/unit/core/test_types.py
@@ -7,6 +7,7 @@ and proper ID generation.
 from uuid import UUID
 
 import pytest
+
 from coaching.src.core.types import (
     create_analysis_request_id,
     create_conversation_id,

--- a/coaching/tests/unit/domain/entities/test_ai_job.py
+++ b/coaching/tests/unit/domain/entities/test_ai_job.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.domain.entities.ai_job import (
     AIJob,
     AIJobErrorCode,

--- a/coaching/tests/unit/domain/entities/test_analysis_request.py
+++ b/coaching/tests/unit/domain/entities/test_analysis_request.py
@@ -1,6 +1,8 @@
 """Unit tests for AnalysisRequest value object."""
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.core.constants import AnalysisType
 from coaching.src.core.types import (
     create_analysis_request_id,
@@ -8,7 +10,6 @@ from coaching.src.core.types import (
     create_user_id,
 )
 from coaching.src.domain.entities.analysis_request import AnalysisRequest
-from pydantic import ValidationError
 
 
 class TestAnalysisRequestCreation:

--- a/coaching/tests/unit/domain/entities/test_coaching_session.py
+++ b/coaching/tests/unit/domain/entities/test_coaching_session.py
@@ -7,6 +7,7 @@ message handling, and lifecycle operations.
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.core.constants import ConversationStatus, MessageRole
 from coaching.src.core.types import TenantId, UserId
 from coaching.src.domain.entities.coaching_session import (

--- a/coaching/tests/unit/domain/entities/test_conversation.py
+++ b/coaching/tests/unit/domain/entities/test_conversation.py
@@ -1,6 +1,7 @@
 """Unit tests for Conversation aggregate root."""
 
 import pytest
+
 from coaching.src.core.constants import (
     CoachingTopic,
     ConversationPhase,

--- a/coaching/tests/unit/domain/entities/test_llm_topic.py
+++ b/coaching/tests/unit/domain/entities/test_llm_topic.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.domain.entities.llm_topic import (
     LLMTopic,
     ParameterDefinition,

--- a/coaching/tests/unit/domain/entities/test_prompt_template.py
+++ b/coaching/tests/unit/domain/entities/test_prompt_template.py
@@ -1,10 +1,11 @@
 """Unit tests for PromptTemplate aggregate root."""
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.core.constants import CoachingTopic, ConversationPhase
 from coaching.src.core.types import create_template_id
 from coaching.src.domain.entities.prompt_template import PromptTemplate
-from pydantic import ValidationError
 
 pytestmark = pytest.mark.unit
 

--- a/coaching/tests/unit/domain/events/test_analysis_events.py
+++ b/coaching/tests/unit/domain/events/test_analysis_events.py
@@ -1,6 +1,7 @@
 """Unit tests for analysis domain events."""
 
 import pytest
+
 from coaching.src.core.constants import AnalysisType
 from coaching.src.domain.events.analysis_events import (
     AnalysisCompleted,

--- a/coaching/tests/unit/domain/events/test_base_event.py
+++ b/coaching/tests/unit/domain/events/test_base_event.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.domain.events.base_event import DomainEvent
 
 

--- a/coaching/tests/unit/domain/events/test_conversation_events.py
+++ b/coaching/tests/unit/domain/events/test_conversation_events.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.core.constants import CoachingTopic, ConversationPhase, MessageRole
 from coaching.src.domain.events.conversation_events import (
     ConversationCompleted,

--- a/coaching/tests/unit/domain/exceptions/test_base_exception.py
+++ b/coaching/tests/unit/domain/exceptions/test_base_exception.py
@@ -1,6 +1,7 @@
 """Unit tests for base DomainException."""
 
 import pytest
+
 from coaching.src.domain.exceptions.base_exception import DomainException
 
 

--- a/coaching/tests/unit/domain/exceptions/test_conversation_exceptions.py
+++ b/coaching/tests/unit/domain/exceptions/test_conversation_exceptions.py
@@ -1,6 +1,7 @@
 """Unit tests for conversation domain exceptions."""
 
 import pytest
+
 from coaching.src.core.constants import ConversationPhase, ConversationStatus
 from coaching.src.domain.exceptions.conversation_exceptions import (
     ConversationCompletionError,

--- a/coaching/tests/unit/domain/services/test_alignment_calculator.py
+++ b/coaching/tests/unit/domain/services/test_alignment_calculator.py
@@ -1,6 +1,7 @@
 """Unit tests for AlignmentCalculator domain service."""
 
 import pytest
+
 from coaching.src.domain.services.alignment_calculator import AlignmentCalculator
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/domain/services/test_completion_validator.py
+++ b/coaching/tests/unit/domain/services/test_completion_validator.py
@@ -1,6 +1,7 @@
 """Unit tests for CompletionValidator domain service."""
 
 import pytest
+
 from coaching.src.core.constants import CoachingTopic, ConversationPhase, MessageRole
 from coaching.src.core.types import (
     create_conversation_id,

--- a/coaching/tests/unit/domain/services/test_phase_transition_service.py
+++ b/coaching/tests/unit/domain/services/test_phase_transition_service.py
@@ -1,6 +1,7 @@
 """Unit tests for PhaseTransitionService domain service."""
 
 import pytest
+
 from coaching.src.core.constants import (
     CoachingTopic,
     ConversationPhase,

--- a/coaching/tests/unit/domain/value_objects/test_alignment_score.py
+++ b/coaching/tests/unit/domain/value_objects/test_alignment_score.py
@@ -1,12 +1,13 @@
 """Unit tests for alignment score value objects."""
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.domain.value_objects.alignment_score import (
     AlignmentScore,
     ComponentScores,
     FoundationAlignment,
 )
-from pydantic import ValidationError
 
 
 class TestComponentScores:

--- a/coaching/tests/unit/domain/value_objects/test_conversation_context.py
+++ b/coaching/tests/unit/domain/value_objects/test_conversation_context.py
@@ -1,11 +1,12 @@
 """Unit tests for ConversationContext value object."""
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.core.constants import ConversationPhase
 from coaching.src.domain.value_objects.conversation_context import (
     ConversationContext,
 )
-from pydantic import ValidationError
 
 pytestmark = pytest.mark.unit
 

--- a/coaching/tests/unit/domain/value_objects/test_message.py
+++ b/coaching/tests/unit/domain/value_objects/test_message.py
@@ -3,9 +3,10 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.core.constants import MessageRole
 from coaching.src.domain.value_objects.message import Message
-from pydantic import ValidationError
 
 
 class TestMessageCreation:

--- a/coaching/tests/unit/infrastructure/cache/test_in_memory_cache.py
+++ b/coaching/tests/unit/infrastructure/cache/test_in_memory_cache.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import pytest
+
 from coaching.src.infrastructure.cache.in_memory_cache import InMemoryCache
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/infrastructure/llm/test_google_vertex_provider.py
+++ b/coaching/tests/unit/infrastructure/llm/test_google_vertex_provider.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage
 from coaching.src.infrastructure.llm.google_vertex_provider import GoogleVertexLLMProvider
 

--- a/coaching/tests/unit/infrastructure/llm/test_provider_factory.py
+++ b/coaching/tests/unit/infrastructure/llm/test_provider_factory.py
@@ -7,6 +7,7 @@ model selection based on MODEL_REGISTRY configuration.
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from coaching.src.core.config_multitenant import Settings
 from coaching.src.core.llm_models import MODEL_REGISTRY, LLMProvider
 from coaching.src.infrastructure.llm.exceptions import (

--- a/coaching/tests/unit/infrastructure/repositories/llm_config/test_template_metadata_repository.py
+++ b/coaching/tests/unit/infrastructure/repositories/llm_config/test_template_metadata_repository.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
+
 from coaching.src.domain.entities.llm_config.template_metadata import TemplateMetadata
 from coaching.src.infrastructure.repositories.llm_config.template_metadata_repository import (
     TemplateMetadataRepository,

--- a/coaching/tests/unit/infrastructure/repositories/test_dynamodb_conversation_repository.py
+++ b/coaching/tests/unit/infrastructure/repositories/test_dynamodb_conversation_repository.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
+
 from coaching.src.core.constants import (
     CoachingTopic,
     ConversationStatus,

--- a/coaching/tests/unit/integration/sql_template/test_service.py
+++ b/coaching/tests/unit/integration/sql_template/test_service.py
@@ -6,6 +6,8 @@ from typing import Any
 from uuid import UUID
 
 import pytest
+from pydantic import ValidationError as PydanticValidationError
+
 from coaching.src.integration.sql_template.enums import ErrorCode, ErrorStage
 from coaching.src.integration.sql_template.errors import SqlTemplateGenerationError
 from coaching.src.integration.sql_template.idempotency import InMemoryGenerationIdempotencyStore
@@ -17,7 +19,6 @@ from coaching.src.integration.sql_template.service import (
 )
 from coaching.src.integration.sql_template.sql_generator import SqlTemplateGenerator
 from coaching.src.integration.sql_template.sql_validator import SqlTemplateValidator
-from pydantic import ValidationError as PydanticValidationError
 
 
 class StubDiscoveryClient:

--- a/coaching/tests/unit/integration/sql_template/test_sql_validator.py
+++ b/coaching/tests/unit/integration/sql_template/test_sql_validator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from coaching.src.integration.sql_template.enums import ValidationFailureCode, ValidationMethod
 from coaching.src.integration.sql_template.errors import ValidationError
 from coaching.src.integration.sql_template.models import RequestedEvent, SqlGenerationResult

--- a/coaching/tests/unit/llm/providers/test_bedrock.py
+++ b/coaching/tests/unit/llm/providers/test_bedrock.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncIterator, Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from coaching.src.llm.providers.base import ProviderConfig, ProviderType
 from coaching.src.llm.providers.bedrock import BedrockProvider
 

--- a/coaching/tests/unit/models/test_coaching_results.py
+++ b/coaching/tests/unit/models/test_coaching_results.py
@@ -4,6 +4,8 @@ Tests for the Pydantic models used to capture final coaching session results.
 """
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.models.coaching_results import (
     COACHING_RESULT_MODELS,
     CoreValue,
@@ -13,7 +15,6 @@ from coaching.src.models.coaching_results import (
     get_coaching_result_model,
     get_result_json_schema,
 )
-from pydantic import ValidationError
 
 
 class TestCoreValue:

--- a/coaching/tests/unit/models/test_email_insight_response.py
+++ b/coaching/tests/unit/models/test_email_insight_response.py
@@ -3,8 +3,9 @@
 from datetime import UTC, datetime
 
 import pytest
-from coaching.src.models.responses import EmailInsightResponse
 from pydantic import ValidationError
+
+from coaching.src.models.responses import EmailInsightResponse
 
 
 @pytest.mark.unit

--- a/coaching/tests/unit/models/test_llm_coaching_response.py
+++ b/coaching/tests/unit/models/test_llm_coaching_response.py
@@ -1,6 +1,7 @@
 """Unit tests for LLM coaching response model and parsing."""
 
 import pytest
+
 from coaching.src.models.llm_coaching_response import (
     AUTO_COMPLETION_CONFIDENCE_THRESHOLD,
     LLMCoachingResponse,

--- a/coaching/tests/unit/repositories/test_topic_repository.py
+++ b/coaching/tests/unit/repositories/test_topic_repository.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
+
 from coaching.src.domain.entities.llm_topic import (
     LLMTopic,
     PromptInfo,

--- a/coaching/tests/unit/services/test_async_execution_service.py
+++ b/coaching/tests/unit/services/test_async_execution_service.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from coaching.src.api.models.ai_job_kickoff import ApiAiJobRequestedDetail
 from coaching.src.domain.entities.ai_job import AIJob, AIJobErrorCode, AIJobStatus
 from coaching.src.services.async_execution_service import (

--- a/coaching/tests/unit/services/test_audit_log_service.py
+++ b/coaching/tests/unit/services/test_audit_log_service.py
@@ -3,6 +3,7 @@
 from datetime import UTC, datetime
 
 import pytest
+
 from coaching.src.services.audit_log_service import (
     AuditAction,
     AuditLogEntry,

--- a/coaching/tests/unit/services/test_coaching_session_service.py
+++ b/coaching/tests/unit/services/test_coaching_session_service.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
 from coaching.src.core.constants import ConversationStatus, TopicCategory, TopicType
 from coaching.src.core.topic_registry import (
     TemplateType,

--- a/coaching/tests/unit/services/test_conversation_service.py
+++ b/coaching/tests/unit/services/test_conversation_service.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from coaching.src.core.constants import CoachingTopic, ConversationStatus
 from coaching.src.core.exceptions import ConversationNotFoundError
 from coaching.src.domain.entities.prompt_template import PromptTemplate

--- a/coaching/tests/unit/services/test_llm_template_service.py
+++ b/coaching/tests/unit/services/test_llm_template_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from botocore.exceptions import ClientError
+
 from coaching.src.domain.entities.llm_config.template_metadata import TemplateMetadata
 from coaching.src.infrastructure.repositories.llm_config.template_metadata_repository import (
     TemplateMetadataRepository,

--- a/coaching/tests/unit/services/test_multitenant_conversation_service.py
+++ b/coaching/tests/unit/services/test_multitenant_conversation_service.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
 from coaching.src.models.conversation import Conversation, Message
 from coaching.src.models.prompt import LLMConfig, PromptTemplate
 from coaching.src.models.responses import (

--- a/coaching/tests/unit/services/test_parameter_gathering_service.py
+++ b/coaching/tests/unit/services/test_parameter_gathering_service.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from coaching.src.core.constants import ParameterSource, TopicCategory, TopicType
 from coaching.src.core.topic_registry import ParameterRef, TopicDefinition
 from coaching.src.services.parameter_gathering_service import ParameterGatheringService

--- a/coaching/tests/unit/services/test_prompt_service.py
+++ b/coaching/tests/unit/services/test_prompt_service.py
@@ -31,6 +31,7 @@ if "boto3" not in sys.modules:
     sys.modules["boto3.dynamodb.conditions"] = conditions_module
 
 import pytest
+
 from coaching.src.domain.entities.llm_topic import LLMTopic
 from coaching.src.domain.exceptions.topic_exceptions import TopicNotFoundError
 from coaching.src.models.prompt import PromptTemplate

--- a/coaching/tests/unit/services/test_s3_prompt_storage.py
+++ b/coaching/tests/unit/services/test_s3_prompt_storage.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from botocore.exceptions import ClientError
+
 from coaching.src.domain.exceptions.topic_exceptions import S3StorageError
 from coaching.src.services.s3_prompt_storage import S3PromptStorage
 

--- a/coaching/tests/unit/services/test_template_parameter_processor.py
+++ b/coaching/tests/unit/services/test_template_parameter_processor.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from coaching.src.core.parameter_registry import ParameterDefinition, ParameterType
 from coaching.src.core.retrieval_method_registry import RetrievalContext
 from coaching.src.services.template_parameter_processor import (

--- a/coaching/tests/unit/services/test_topic_seeding_service.py
+++ b/coaching/tests/unit/services/test_topic_seeding_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
 from coaching.src.core.topic_seed_data import TopicSeedData, get_seed_data_for_topic
 from coaching.src.domain.entities.llm_topic import LLMTopic
 from coaching.src.services.topic_seeding_service import (

--- a/coaching/tests/unit/services/test_user_limits_service.py
+++ b/coaching/tests/unit/services/test_user_limits_service.py
@@ -2,6 +2,7 @@ import time
 from unittest.mock import Mock, patch
 
 import pytest
+
 from coaching.src.services.user_limits_service import UserLimitsCache, UserLimitsService
 
 pytestmark = pytest.mark.unit

--- a/coaching/tests/unit/services/test_website_analysis_service.py
+++ b/coaching/tests/unit/services/test_website_analysis_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
 from coaching.src.llm.providers.manager import ProviderManager
 from coaching.src.services.website_analysis_service import WebsiteAnalysisService
 

--- a/coaching/tests/unit/test_bedrock_provider.py
+++ b/coaching/tests/unit/test_bedrock_provider.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 from coaching.src.domain.ports.llm_provider_port import LLMMessage
 from coaching.src.infrastructure.llm.bedrock_provider import BedrockLLMProvider
 

--- a/coaching/tests/unit/test_business_api_client.py
+++ b/coaching/tests/unit/test_business_api_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 
 import httpx
 import pytest
+
 from coaching.src.infrastructure.external.business_api_client import BusinessApiClient
 
 

--- a/coaching/tests/unit/test_constants.py
+++ b/coaching/tests/unit/test_constants.py
@@ -1,6 +1,7 @@
 """Unit tests for core constants and enums."""
 
 import pytest
+
 from coaching.src.core.constants import (
     AnalysisType,
     CoachingTopic,

--- a/coaching/tests/unit/test_exceptions.py
+++ b/coaching/tests/unit/test_exceptions.py
@@ -1,6 +1,7 @@
 """Unit tests for custom exceptions."""
 
 import pytest
+
 from coaching.src.core.exceptions import (
     ConversationNotFoundCompatError,
     ConversationNotFoundError,

--- a/coaching/tests/unit/test_insights_service.py
+++ b/coaching/tests/unit/test_insights_service.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
 from coaching.src.infrastructure.external.business_api_client import BusinessApiClient
 from coaching.src.infrastructure.repositories.dynamodb_conversation_repository import (
     DynamoDBConversationRepository,

--- a/coaching/tests/unit/test_model_pricing.py
+++ b/coaching/tests/unit/test_model_pricing.py
@@ -1,6 +1,7 @@
 """Unit tests for model pricing calculations."""
 
 import pytest
+
 from coaching.src.infrastructure.llm.model_pricing import (
     MODEL_PRICING,
     calculate_cost,

--- a/coaching/tests/unit/test_models.py
+++ b/coaching/tests/unit/test_models.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import pytest
+
 from coaching.src.core.constants import (
     CoachingTopic,
     ConversationPhase,

--- a/coaching/tests/unit/test_onboarding_models.py
+++ b/coaching/tests/unit/test_onboarding_models.py
@@ -1,6 +1,8 @@
 """Unit tests for Onboarding Pydantic models (Issue #48)."""
 
 import pytest
+from pydantic import ValidationError
+
 from coaching.src.api.models.onboarding import (
     OnboardingCoachingRequest,
     OnboardingCoachingResponse,
@@ -14,7 +16,6 @@ from coaching.src.api.models.onboarding import (
     WebsiteScanTargetMarket,
     WebsiteScanValueProposition,
 )
-from pydantic import ValidationError
 
 
 @pytest.mark.unit

--- a/coaching/tests/unit/test_onboarding_service.py
+++ b/coaching/tests/unit/test_onboarding_service.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
+
 from coaching.src.services.onboarding_service import OnboardingService
 
 

--- a/coaching/tests/unit/test_response_models.py
+++ b/coaching/tests/unit/test_response_models.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 
 import pytest
+
 from coaching.src.core.constants import ConversationPhase, ConversationStatus
 from coaching.src.models.responses import (
     ConversationListResponse,

--- a/coaching/tests/unit/workflows/test_analysis_workflow_template.py
+++ b/coaching/tests/unit/workflows/test_analysis_workflow_template.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from coaching.src.workflows.analysis_workflow_template import AnalysisWorkflowTemplate
 from coaching.src.workflows.base import WorkflowConfig, WorkflowStatus
 

--- a/coaching/tests/unit/workflows/test_coaching_workflow_nodes.py
+++ b/coaching/tests/unit/workflows/test_coaching_workflow_nodes.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from coaching.src.application.conversation.conversation_service import (
     ConversationApplicationService,
 )

--- a/coaching/tests/unit/workflows/test_conversation_workflow_template.py
+++ b/coaching/tests/unit/workflows/test_conversation_workflow_template.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from coaching.src.workflows.base import WorkflowConfig, WorkflowStatus
 from coaching.src.workflows.conversation_workflow_template import ConversationWorkflowTemplate
 

--- a/coaching/tests/unit/workflows/test_refactored_workflows.py
+++ b/coaching/tests/unit/workflows/test_refactored_workflows.py
@@ -7,6 +7,7 @@ analysis_workflow.py properly integrate with domain entities and services.
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from coaching.src.application.analysis.base_analysis_service import BaseAnalysisService
 from coaching.src.application.conversation.conversation_service import (
     ConversationApplicationService,


### PR DESCRIPTION
## Cause

GitHub **CI/CD Pipeline** and **Deploy Dev** failed on `ruff check` with **I001** on `unified_ai_engine.py` after merging #310.

Ruff resolves `coaching/pyproject.toml` for files under `coaching/`. That file had no `[tool.ruff.lint.isort] known-first-party`, so `coaching.*` imports were sorted as third-party relative to `structlog` / `pydantic`, producing invalid import blocks.

## Fix

- Add `known-first-party = ["coaching", "shared"]` to `coaching/pyproject.toml` (aligned with repo root `pyproject.toml`).
- Run `ruff check coaching/ --fix` so the tree matches the corrected isort rules (~199 I001 fixes).

## Verification

- `ruff==0.8.4` `ruff check coaching/ shared/` — clean
- `pytest coaching/tests/unit/application/ai_engine/test_llm_json_schema_adaptation.py` — 5 passed

Unblocks redeploy to dev.
