### PR TITLE
fix(#327): topic seeding on deploy + TOPIC_NOT_CONFIGURED

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -132,6 +132,22 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
 
+      - name: Set up uv (topic seeding)
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Seed topic registry (DynamoDB + S3 prompts)
+        shell: bash
+        run: |
+          uv venv .venv-seed
+          source .venv-seed/bin/activate
+          uv pip install -r coaching/requirements.txt
+          export PYTHONPATH="coaching:shared:."
+          export STAGE=dev
+          export AWS_REGION=us-east-1
+          python -m coaching.src.scripts.seed_topics
+
       - name: Get API Gateway URL
         id: api-url
         working-directory: coaching/pulumi

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -197,6 +197,22 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
 
+      - name: Set up uv (topic seeding)
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Seed topic registry (DynamoDB + S3 prompts)
+        shell: bash
+        run: |
+          uv venv .venv-seed
+          source .venv-seed/bin/activate
+          uv pip install -r coaching/requirements.txt
+          export PYTHONPATH="coaching:shared:."
+          export STAGE=prod
+          export AWS_REGION=us-east-1
+          python -m coaching.src.scripts.seed_topics
+
       - name: Get API Gateway URL
         id: api-url
         working-directory: coaching/pulumi

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -157,6 +157,22 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: us-east-1
 
+      - name: Set up uv (topic seeding)
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Seed topic registry (DynamoDB + S3 prompts)
+        shell: bash
+        run: |
+          uv venv .venv-seed
+          source .venv-seed/bin/activate
+          uv pip install -r coaching/requirements.txt
+          export PYTHONPATH="coaching:shared:."
+          export STAGE=staging
+          export AWS_REGION=us-east-1
+          python -m coaching.src.scripts.seed_topics
+
       - name: Get API Gateway URL
         id: api-url
         working-directory: coaching/pulumi

--- a/coaching/src/api/routes/coaching_sessions.py
+++ b/coaching/src/api/routes/coaching_sessions.py
@@ -33,7 +33,8 @@ Error Responses:
     410 - SESSION_EXPIRED: Session has expired or timed out
     422 - SESSION_NOT_FOUND: Session not found
     422 - MAX_TURNS_REACHED: Maximum conversation turns reached
-    422 - INVALID_TOPIC: Topic not found or invalid
+    422 - INVALID_TOPIC: Topic id not in coaching registry
+    422 - TOPIC_NOT_CONFIGURED: Registry topic exists but DynamoDB LLMTopic row is missing (run topic seeding)
     500 - EXTRACTION_FAILED: Failed to extract results from session
 """
 
@@ -365,10 +366,15 @@ async def start_session(
             "coaching_sessions.start_session.invalid_topic",
             topic_id=request.topic_id,
             tenant_id=context.tenant_id,
+            error_code=e.error_code,
         )
         raise HTTPException(
             status_code=422,
-            detail={"code": "INVALID_TOPIC", "message": str(e)},
+            detail={
+                "code": e.error_code,
+                "message": str(e),
+                "topic_id": e.topic_id,
+            },
         ) from e
 
     except TopicNotActiveError as e:

--- a/coaching/src/services/coaching_session_service.py
+++ b/coaching/src/services/coaching_session_service.py
@@ -64,9 +64,16 @@ logger = structlog.get_logger()
 class InvalidTopicError(Exception):
     """Raised when topic is not found or not valid for coaching."""
 
-    def __init__(self, topic_id: str, reason: str = "Topic not found") -> None:
+    def __init__(
+        self,
+        topic_id: str,
+        reason: str = "Topic not found",
+        *,
+        error_code: str = "INVALID_TOPIC",
+    ) -> None:
         self.topic_id = topic_id
         self.reason = reason
+        self.error_code = error_code
         super().__init__(f"Invalid topic '{topic_id}': {reason}")
 
 
@@ -304,6 +311,7 @@ class CoachingSessionService:
             raise InvalidTopicError(
                 topic_id=topic_id,
                 reason="Topic not found in ENDPOINT_REGISTRY for CONVERSATION_COACHING",
+                error_code="INVALID_TOPIC",
             )
         return endpoint
 
@@ -325,6 +333,7 @@ class CoachingSessionService:
             raise InvalidTopicError(
                 topic_id=topic_id,
                 reason="LLMTopic configuration not found in database",
+                error_code="TOPIC_NOT_CONFIGURED",
             )
         if not llm_topic.is_active:
             raise TopicNotActiveError(topic_id=topic_id)

--- a/coaching/tests/integration/api/test_coaching_sessions.py
+++ b/coaching/tests/integration/api/test_coaching_sessions.py
@@ -290,6 +290,26 @@ class TestStartSession:
         assert response.status_code == 422
         data = response.json()
         assert data["detail"]["code"] == "INVALID_TOPIC"
+        assert data["detail"]["topic_id"] == "invalid_topic"
+
+    def test_start_session_topic_not_configured(self, client, mock_coaching_session_service):
+        """Missing LLMTopic row returns TOPIC_NOT_CONFIGURED for actionable client copy."""
+        mock_coaching_session_service.get_or_create_session.side_effect = InvalidTopicError(
+            topic_id="issue_root_cause_coaching",
+            reason="LLMTopic configuration not found in database",
+            error_code="TOPIC_NOT_CONFIGURED",
+        )
+
+        response = client.post(
+            "/api/v1/ai/coaching/start",
+            json={"topic_id": "issue_root_cause_coaching", "context": {"issue_id": "i1"}},
+            headers={"Authorization": "Bearer test_token"},
+        )
+
+        assert response.status_code == 422
+        data = response.json()
+        assert data["detail"]["code"] == "TOPIC_NOT_CONFIGURED"
+        assert data["detail"]["topic_id"] == "issue_root_cause_coaching"
 
 
 class TestSendMessage:

--- a/coaching/tests/unit/services/test_coaching_session_service.py
+++ b/coaching/tests/unit/services/test_coaching_session_service.py
@@ -279,6 +279,29 @@ class TestCoachingSessionService:
 
         assert exc_info.value.topic_id == "nonexistent_topic"
         assert "not found" in exc_info.value.reason.lower()
+        assert exc_info.value.error_code == "INVALID_TOPIC"
+
+    @pytest.mark.asyncio
+    async def test_initiate_missing_llm_topic_row_raises_topic_not_configured(
+        self,
+        service: CoachingSessionService,
+        mock_topic_repository: AsyncMock,
+        sample_endpoint_definition: TopicDefinition,
+    ) -> None:
+        """Missing DynamoDB LLMTopic row should surface TOPIC_NOT_CONFIGURED."""
+        service._topic_index["core_values"] = sample_endpoint_definition
+        mock_topic_repository.get.return_value = None
+
+        with pytest.raises(InvalidTopicError) as exc_info:
+            await service.get_or_create_session(
+                topic_id="core_values",
+                tenant_id="tenant-123",
+                user_id="user-123",
+            )
+
+        assert exc_info.value.topic_id == "core_values"
+        assert exc_info.value.error_code == "TOPIC_NOT_CONFIGURED"
+        assert "database" in exc_info.value.reason.lower()
 
     @pytest.mark.asyncio
     async def test_initiate_inactive_topic_raises_error(


### PR DESCRIPTION
## Summary

Resolves investigation from PurposePath_Web #867: `POST /ai/coaching/start` with `issue_root_cause_coaching` failed when the **LLMTopic** row was missing in DynamoDB even though the topic exists in code.

## Changes

- **Deploy workflows** (`deploy-dev`, `deploy-staging`, `deploy-production`): after Pulumi coaching deploy, run `python -m coaching.src.scripts.seed_topics` (no `--force-update`) so new registry topics are created in `purposepath-topics-{stage}` and prompts in S3.
- **API**: Missing DynamoDB config now returns HTTP 422 with `"code": "TOPIC_NOT_CONFIGURED"` and `"topic_id"` in `detail`. Unknown topic id still uses `INVALID_TOPIC`.

## Testing

- Unit: `test_initiate_missing_llm_topic_row_raises_topic_not_configured`, extended invalid-topic assertion.
- Integration: `test_start_session_topic_not_configured`, extended invalid-topic response shape.

Closes #327 when merged.
