### PR TITLE
fix(deploy): CI topic seeding — correct S3 bucket + missing seed non-fatal

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -146,6 +146,8 @@ jobs:
           export PYTHONPATH="coaching:shared:."
           export STAGE=dev
           export AWS_REGION=us-east-1
+          # Must match infrastructure/pulumi S3 bucket (purposepath-coaching-prompts-<account>-<stack>)
+          export PROMPTS_BUCKET="purposepath-coaching-prompts-380276784420-${STAGE}"
           python -m coaching.src.scripts.seed_topics
 
       - name: Get API Gateway URL

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -211,6 +211,7 @@ jobs:
           export PYTHONPATH="coaching:shared:."
           export STAGE=prod
           export AWS_REGION=us-east-1
+          export PROMPTS_BUCKET="purposepath-coaching-prompts-380276784420-${STAGE}"
           python -m coaching.src.scripts.seed_topics
 
       - name: Get API Gateway URL

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -171,6 +171,7 @@ jobs:
           export PYTHONPATH="coaching:shared:."
           export STAGE=staging
           export AWS_REGION=us-east-1
+          export PROMPTS_BUCKET="purposepath-coaching-prompts-380276784420-${STAGE}"
           python -m coaching.src.scripts.seed_topics
 
       - name: Get API Gateway URL

--- a/coaching/src/scripts/seed_topics.py
+++ b/coaching/src/scripts/seed_topics.py
@@ -148,6 +148,14 @@ async def seed_all_topics(
             for topic_id in sorted(result.deactivated):
                 print_warning(f"{topic_id} (no endpoint)")
 
+        if result.missing_seed_topics:
+            print(
+                f"\n{Colors.WARNING}Registry topics without seed data "
+                f"({len(result.missing_seed_topics)}):{Colors.ENDC}"
+            )
+            for topic_id in sorted(result.missing_seed_topics):
+                print_warning(f"{topic_id} (add TopicSeedData or remove from registry)")
+
         if result.errors:
             print(f"\n{Colors.FAIL}Errors ({len(result.errors)}):{Colors.ENDC}")
             for topic_id, error in result.errors:
@@ -160,6 +168,7 @@ async def seed_all_topics(
         print(f"Updated:          {len(result.updated)}")
         print(f"Skipped:          {len(result.skipped)}")
         print(f"Deactivated:      {len(result.deactivated)}")
+        print(f"Missing seed:     {len(result.missing_seed_topics)}")
         print(f"Errors:           {len(result.errors)}")
 
         if result.is_successful:

--- a/coaching/src/services/topic_seeding_service.py
+++ b/coaching/src/services/topic_seeding_service.py
@@ -35,6 +35,7 @@ class SeedingResult:
         skipped: Topic IDs that were skipped (already exist, no force update)
         deactivated: Topic IDs that were deactivated (orphaned)
         errors: List of (topic_id, error_message) tuples for failed operations
+        missing_seed_topics: Registry topic IDs with no TopicSeedData (non-fatal)
     """
 
     created: list[str] = field(default_factory=list)
@@ -42,6 +43,7 @@ class SeedingResult:
     skipped: list[str] = field(default_factory=list)
     deactivated: list[str] = field(default_factory=list)
     errors: list[tuple[str, str]] = field(default_factory=list)
+    missing_seed_topics: list[str] = field(default_factory=list)
 
     @property
     def total_processed(self) -> int:
@@ -151,9 +153,11 @@ class TopicSeedingService:
                 # Get seed data
                 seed_data = get_seed_data_for_topic(topic_id)
                 if seed_data is None:
-                    error_msg = f"No seed data found for topic {topic_id}"
-                    logger.warning(error_msg, topic_id=topic_id)
-                    result.errors.append((topic_id, error_msg))
+                    logger.warning(
+                        "No seed data for registry topic (skipped)",
+                        topic_id=topic_id,
+                    )
+                    result.missing_seed_topics.append(topic_id)
                     continue
 
                 # Check if topic exists
@@ -211,6 +215,7 @@ class TopicSeedingService:
             skipped=len(result.skipped),
             deactivated=len(result.deactivated),
             errors=len(result.errors),
+            missing_seed_topics=len(result.missing_seed_topics),
             dry_run=dry_run,
         )
 

--- a/coaching/tests/unit/services/test_topic_seeding_service.py
+++ b/coaching/tests/unit/services/test_topic_seeding_service.py
@@ -48,12 +48,41 @@ class TestTopicSeedingService:
         assert result.failure_count == 1
         assert not result.is_successful
 
+        result2 = SeedingResult()
+        result2.missing_seed_topics = ["orphan_registry_topic"]
+        assert result2.is_successful
+
     def test_validation_report_properties(self) -> None:
         report = ValidationReport()
         assert report.is_valid
 
         report.missing_topics = ["topic1"]
         assert not report.is_valid
+
+    @pytest.mark.asyncio
+    async def test_seed_all_topics_missing_seed_data_not_counted_as_error(
+        self, service: TopicSeedingService, mock_topic_repo: Mock, mock_s3_storage: Mock
+    ) -> None:
+        """Registry topics without TopicSeedData should not fail the seeding run."""
+        with (
+            patch(
+                "coaching.src.services.topic_seeding_service.list_all_topics"
+            ) as mock_list_topics,
+            patch(
+                "coaching.src.services.topic_seeding_service.get_seed_data_for_topic"
+            ) as mock_get_seed,
+        ):
+            ep = Mock()
+            ep.topic_id = "registry_only_topic"
+            mock_list_topics.return_value = [ep]
+            mock_get_seed.return_value = None
+
+            result = await service.seed_all_topics(force_update=False)
+
+        assert result.missing_seed_topics == ["registry_only_topic"]
+        assert result.errors == []
+        assert result.is_successful
+        assert not mock_topic_repo.create.called
 
     @pytest.mark.asyncio
     async def test_seed_all_topics_creates_new(
@@ -65,7 +94,7 @@ class TestTopicSeedingService:
 
         with (
             patch(
-                "coaching.src.services.topic_seeding_service.list_all_endpoints"
+                "coaching.src.services.topic_seeding_service.list_all_topics"
             ) as mock_list_endpoints,
             patch(
                 "coaching.src.services.topic_seeding_service.get_seed_data_for_topic"
@@ -112,7 +141,7 @@ class TestTopicSeedingService:
 
         with (
             patch(
-                "coaching.src.services.topic_seeding_service.list_all_endpoints"
+                "coaching.src.services.topic_seeding_service.list_all_topics"
             ) as mock_list_endpoints,
             patch(
                 "coaching.src.services.topic_seeding_service.get_seed_data_for_topic"
@@ -148,7 +177,7 @@ class TestTopicSeedingService:
 
         with (
             patch(
-                "coaching.src.services.topic_seeding_service.list_all_endpoints"
+                "coaching.src.services.topic_seeding_service.list_all_topics"
             ) as mock_list_endpoints,
             patch(
                 "coaching.src.services.topic_seeding_service.get_seed_data_for_topic"
@@ -192,7 +221,7 @@ class TestTopicSeedingService:
 
         with (
             patch(
-                "coaching.src.services.topic_seeding_service.list_all_endpoints"
+                "coaching.src.services.topic_seeding_service.list_all_topics"
             ) as mock_list_endpoints,
             patch(
                 "coaching.src.services.topic_seeding_service.get_seed_data_for_topic"


### PR DESCRIPTION
## Problem

Deploy Dev failed on the post-merge **Seed topic registry** step: `NoSuchBucket` for `purposepath-coaching-prompts-dev`. The seed script used `Settings` defaults while **infrastructure/pulumi** creates `purposepath-coaching-prompts-380276784420-<stack>` (see `infrastructure/pulumi/__main__.py`).

After fixing the bucket, seeding would still exit **1** because many registry topics have no `TopicSeedData` row; those were counted as `errors`.

## Changes

1. **Workflows** (`deploy-dev`, `deploy-staging`, `deploy-production`): export `PROMPTS_BUCKET=purposepath-coaching-prompts-380276784420-${STAGE}` before running `seed_topics`.

2. **TopicSeedingService**: topics with no seed data go to `SeedingResult.missing_seed_topics` (warning path), not `errors`, so `is_successful` stays true when Dynamo/S3 operations succeed.

3. **seed_topics CLI**: print a **Registry topics without seed data** section and summary line `Missing seed:`.

4. **Tests**: patch `list_all_topics` (what the service actually calls); add test for missing-seed behavior; assert `missing_seed_topics` does not fail `is_successful`.

## Validation

`pytest coaching/tests/unit/services/test_topic_seeding_service.py -v`; ruff + mypy on touched modules.
